### PR TITLE
refactor: harden mtls tooling (slice 3/9)

### DIFF
--- a/exec/server/main.go
+++ b/exec/server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BurntSushi/toml"
 	flag "github.com/spf13/pflag"
 	"pkg.para.party/certdx/pkg/logging"
+	"pkg.para.party/certdx/pkg/paths"
 	"pkg.para.party/certdx/pkg/server"
 )
 
@@ -24,6 +25,7 @@ var (
 	version  = flag.BoolP("version", "v", false, "Print version")
 	pConf    = flag.StringP("conf", "c", "./server.toml", "Config file path")
 	pDebug   = flag.BoolP("debug", "d", false, "Enable debug log")
+	pMtlsDir = flag.String("mtls-dir", "", "mTLS material directory")
 )
 
 var cdxsrv *server.CertDXServer
@@ -44,6 +46,8 @@ func init() {
 	logging.SetLogFile(*pLogPath)
 	logging.SetDebug(*pDebug)
 	logging.Info("\nStarting certdx server %s, built at %s", buildCommit, buildDate)
+
+	paths.SetMtlsDir(*pMtlsDir)
 
 	cdxsrv = server.MakeCertDXServer()
 

--- a/exec/tools/tasks/make-ca.go
+++ b/exec/tools/tasks/make-ca.go
@@ -5,6 +5,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"pkg.para.party/certdx/pkg/logging"
+	"pkg.para.party/certdx/pkg/paths"
 	"pkg.para.party/certdx/pkg/tools"
 )
 
@@ -14,6 +15,7 @@ func MakeCA() {
 
 		caOrganization = caCMD.StringP("organization", "o", "CertDX Private", "Subject Organization")
 		caCommonName   = caCMD.StringP("common-name", "c", "CertDX Private Certificate Authority", "Subject Common Name")
+		mtlsDir        = caCMD.String("mtls-dir", "", "mTLS material directory")
 		caHelp         = caCMD.BoolP("Help", "h", false, "Print Help")
 	)
 	caCMD.Parse(os.Args[2:])
@@ -22,6 +24,8 @@ func MakeCA() {
 		caCMD.PrintDefaults()
 		os.Exit(0)
 	}
+
+	paths.SetMtlsDir(*mtlsDir)
 
 	err := tools.MakeCA(*caOrganization, *caCommonName)
 	if err != nil {

--- a/exec/tools/tasks/make-client.go
+++ b/exec/tools/tasks/make-client.go
@@ -6,6 +6,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"pkg.para.party/certdx/pkg/logging"
+	"pkg.para.party/certdx/pkg/paths"
 	"pkg.para.party/certdx/pkg/tools"
 )
 
@@ -17,6 +18,7 @@ func MakeClient() {
 		clientDomains      = clientCMD.StringSliceP("dns-names", "d", []string{}, "CertDX grpc client certificate dns names, combine multiple names with \",\"")
 		clientOrganization = clientCMD.StringP("organization", "o", "CertDX Private", "Subject Organization")
 		clientCommonName   = clientCMD.StringP("common-name", "c", "CertDX Client: {name}", "Subject Common Name")
+		mtlsDir            = clientCMD.String("mtls-dir", "", "mTLS material directory")
 		clientHelp         = clientCMD.BoolP("Help", "h", false, "Print Help")
 	)
 	clientCMD.Parse(os.Args[2:])
@@ -33,6 +35,8 @@ func MakeClient() {
 	if *clientCommonName == "CertDX Client: {name}" {
 		*clientCommonName = fmt.Sprintf("CertDX Client: %s", *clientName)
 	}
+
+	paths.SetMtlsDir(*mtlsDir)
 
 	err := tools.MakeClientCert(*clientName, *clientOrganization, *clientCommonName, *clientDomains)
 	if err != nil {

--- a/exec/tools/tasks/make-server.go
+++ b/exec/tools/tasks/make-server.go
@@ -5,6 +5,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"pkg.para.party/certdx/pkg/logging"
+	"pkg.para.party/certdx/pkg/paths"
 	"pkg.para.party/certdx/pkg/tools"
 )
 
@@ -15,6 +16,7 @@ func MakeServer() {
 		srvDomains      = srvCMD.StringSliceP("dns-names", "d", []string{}, "CertDX grpc server certificate dns names, combine multiple names with \",\"")
 		srvOrganization = srvCMD.StringP("organization", "o", "CertDX Private", "Subject Organization")
 		srvCommonName   = srvCMD.StringP("common-name", "c", "CertDX Secret Discovery Service", "Subject Common Name")
+		mtlsDir         = srvCMD.String("mtls-dir", "", "mTLS material directory")
 		srvHelp         = srvCMD.BoolP("Help", "h", false, "Print Help")
 	)
 	srvCMD.Parse(os.Args[2:])
@@ -27,6 +29,8 @@ func MakeServer() {
 	if len(*srvDomains) == 0 {
 		logging.Fatal("domains are required")
 	}
+
+	paths.SetMtlsDir(*mtlsDir)
 
 	err := tools.MakeServerCert(*srvOrganization, *srvCommonName, *srvDomains)
 	if err != nil {

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -40,7 +40,8 @@ func FileExists(path string) bool {
 }
 
 // SetMtlsDir sets a process-local mtls directory override. It is mainly used
-// by --mtls-dir flags.
+// by --mtls-dir flags. Call this during process setup; concurrent mutation is
+// not supported.
 func SetMtlsDir(dir string) {
 	mtlsDirOverride = dir
 }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -29,12 +29,30 @@ const (
 	ServerCacheFile = "cache.json"
 )
 
+var mtlsDirOverride string
+
 // FileExists reports whether the file at path exists. It returns false on
 // any stat error, including permission errors, so callers should not rely on
 // FileExists to distinguish "missing" from "unreadable".
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// SetMtlsDir sets a process-local mtls directory override. It is mainly used
+// by --mtls-dir flags.
+func SetMtlsDir(dir string) {
+	mtlsDirOverride = dir
+}
+
+func ensureMtlsDir(dir string) (string, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
 }
 
 // findFile looks up file under the cwd, then under the directory containing
@@ -65,9 +83,13 @@ func findFile(file string) (string, error) {
 // creates a fresh mtls directory under the directory containing the
 // running executable and returns the new path.
 func MakeMtlsCertDir() (string, error) {
+	if mtlsDirOverride != "" {
+		return ensureMtlsDir(mtlsDirOverride)
+	}
+
 	dir, err := findFile(MtlsCertificateDir)
 	if err == nil {
-		return dir, nil
+		return ensureMtlsDir(dir)
 	}
 
 	exec, err := os.Executable()
@@ -78,14 +100,14 @@ func MakeMtlsCertDir() (string, error) {
 
 	dir = path.Join(dir, MtlsCertificateDir)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.Mkdir(dir, 0o777); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return "", err
 		}
 	} else if err != nil {
 		return "", err
 	}
 
-	return dir, nil
+	return ensureMtlsDir(dir)
 }
 
 // MtlsCAPath returns the on-disk paths to the mtls CA certificate (PEM) and

--- a/pkg/tools/cert.go
+++ b/pkg/tools/cert.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-acme/lego/v4/certcrypto"
@@ -21,6 +22,12 @@ import (
 )
 
 var counter big.Int = *big.NewInt(0)
+
+const (
+	certFileMode = 0o644
+	keyFileMode  = 0o600
+	dataFileMode = 0o644
+)
 
 func MakeCA(organization, commonName string) error {
 	caPEMPath, caKeyPath, err := paths.MtlsCAPath()
@@ -70,7 +77,9 @@ func MakeCA(organization, commonName string) error {
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
-	_ = os.WriteFile(caPEMPath, caPEM, 0o777)
+	if err := os.WriteFile(caPEMPath, caPEM, certFileMode); err != nil {
+		return err
+	}
 
 	b, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
@@ -81,9 +90,13 @@ func MakeCA(organization, commonName string) error {
 		Type:  "PRIVATE KEY",
 		Bytes: b,
 	})
-	_ = os.WriteFile(caKeyPath, caKey, 0o600)
+	if err := os.WriteFile(caKeyPath, caKey, keyFileMode); err != nil {
+		return err
+	}
 
-	_ = os.WriteFile(caCounterPath, []byte(counter.String()), 0o755)
+	if err := os.WriteFile(caCounterPath, []byte(counter.String()), dataFileMode); err != nil {
+		return err
+	}
 	fmt.Println(string(caPEM))
 	return nil
 }
@@ -208,7 +221,9 @@ func makeCert(PEMPath, keyPath, organization, commonName string,
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
 	})
-	_ = os.WriteFile(PEMPath, certPEM, 0o777)
+	if err := os.WriteFile(PEMPath, certPEM, certFileMode); err != nil {
+		return err
+	}
 
 	b, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
@@ -219,10 +234,14 @@ func makeCert(PEMPath, keyPath, organization, commonName string,
 		Type:  "PRIVATE KEY",
 		Bytes: b,
 	})
-	_ = os.WriteFile(keyPath, certKey, 0o777)
+	if err := os.WriteFile(keyPath, certKey, keyFileMode); err != nil {
+		return err
+	}
 
 	counter.Add(&counter, big.NewInt(1))
-	_ = os.WriteFile(counterPath, []byte(counter.String()), 0o755)
+	if err := os.WriteFile(counterPath, []byte(counter.String()), dataFileMode); err != nil {
+		return err
+	}
 
 	fmt.Println(string(certPEM))
 	fmt.Println(string(certKey))
@@ -238,6 +257,11 @@ func MakeServerCert(organization, commonName string, domains []string) error {
 }
 
 func MakeClientCert(name, organization, commonName string, domains []string) error {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "ca", "server":
+		return fmt.Errorf("client name %q is reserved for mtls material", name)
+	}
+
 	clientPEMPath, clientKeyPath, err := paths.MtlsClientCertPath(name)
 	if err != nil {
 		return err

--- a/test/e2e/http_mtls_test.go
+++ b/test/e2e/http_mtls_test.go
@@ -19,10 +19,11 @@ import (
 // TestHTTPMutualTLS: HTTPS + mTLS client-cert authenticated cert delivery.
 func TestHTTPMutualTLS(t *testing.T) {
 	cwd := t.TempDir()
+	chainDir := t.TempDir()
 	port := harness.MustFreePort()
 	const apiPath = "/e2e"
 
-	chain := harness.GenerateChain(t, cwd, []string{"localhost", "127.0.0.1"}, "client1")
+	chain := harness.GenerateChain(t, chainDir, []string{"localhost", "127.0.0.1"}, "client1")
 
 	harness.WriteServerConfig(t, cwd, harness.ServerOpts{
 		AllowedDomains: []string{"example.test", "localhost"},
@@ -33,7 +34,7 @@ func TestHTTPMutualTLS(t *testing.T) {
 		HTTPNames:      []string{"localhost"},
 	})
 
-	srv := harness.Start(t, "server", harness.ServerBin(t), cwd, "-c", filepath.Join(cwd, "server.toml"), "-d")
+	srv := harness.Start(t, "server", harness.ServerBin(t), cwd, "-c", filepath.Join(cwd, "server.toml"), "--mtls-dir", filepath.Join(chainDir, "mtls"), "-d")
 	if err := harness.WaitListening("127.0.0.1", port, 5*time.Second); err != nil {
 		t.Fatalf("server not listening: %s\n%s", err, srv.CombinedOutput())
 	}

--- a/test/e2e/tools_test.go
+++ b/test/e2e/tools_test.go
@@ -3,10 +3,13 @@
 package e2e
 
 import (
+	"context"
 	"crypto/x509"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"pkg.para.party/certdx/test/e2e/harness"
 )
@@ -27,11 +30,14 @@ func TestToolsMakeMTLSCertChain(t *testing.T) {
 		}
 	}
 
-	// CA key should not be world/group readable; tools writes it 0o600.
-	if info, err := os.Stat(chain.CAKey); err != nil {
-		t.Fatalf("stat ca key: %s", err)
-	} else if perm := info.Mode().Perm(); perm&0o077 != 0 {
-		t.Logf("warning: ca.key world/group readable (%o); tooling should tighten this", perm)
+	assertPerm(t, filepath.Join(cwd, "mtls"), 0o700)
+	assertPerm(t, chain.CAPEM, 0o644)
+	assertPerm(t, chain.CAKey, 0o600)
+	assertPerm(t, chain.SrvPEM, 0o644)
+	assertPerm(t, chain.SrvKey, 0o600)
+	for name := range chain.ClientPEM {
+		assertPerm(t, chain.ClientPEM[name], 0o644)
+		assertPerm(t, chain.ClientKey[name], 0o600)
 	}
 
 	ca := harness.LoadCert(t, chain.CAPEM)
@@ -72,6 +78,55 @@ func TestToolsMakeMTLSCertChain(t *testing.T) {
 	}
 }
 
+func TestToolsMakeClientRejectsReservedMTLSNames(t *testing.T) {
+	cwd := t.TempDir()
+	chain := harness.GenerateChain(t, cwd, []string{"localhost"})
+	originalCA := mustReadFile(t, chain.CAPEM)
+	originalServer := mustReadFile(t, chain.SrvPEM)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, name := range []string{"ca", "server"} {
+		out, err := harness.RunTool(ctx, t, cwd, "make-client", "-n", name, "-o", "CertDX E2E")
+		if err == nil {
+			t.Fatalf("make-client %q succeeded; output:\n%s", name, out)
+		}
+		if !strings.Contains(out, "reserved") {
+			t.Fatalf("make-client %q output = %q; want reserved-name error", name, out)
+		}
+	}
+
+	if got := mustReadFile(t, chain.CAPEM); string(got) != string(originalCA) {
+		t.Fatalf("ca.pem changed after reserved-name make-client")
+	}
+	if got := mustReadFile(t, chain.SrvPEM); string(got) != string(originalServer) {
+		t.Fatalf("server.pem changed after reserved-name make-client")
+	}
+}
+
+func TestToolsMTLSDirFlagOverride(t *testing.T) {
+	cwd := t.TempDir()
+	mtlsDir := filepath.Join(t.TempDir(), "flag-mtls")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if out, err := harness.RunTool(ctx, t, cwd, "make-ca", "--mtls-dir", mtlsDir, "-o", "CertDX E2E", "-c", "CertDX E2E CA"); err != nil {
+		t.Fatalf("make-ca with --mtls-dir: %s\n%s", err, out)
+	}
+	if out, err := harness.RunTool(ctx, t, cwd, "make-server", "--mtls-dir", mtlsDir, "-d", "localhost", "-o", "CertDX E2E"); err != nil {
+		t.Fatalf("make-server with --mtls-dir: %s\n%s", err, out)
+	}
+	if out, err := harness.RunTool(ctx, t, cwd, "make-client", "--mtls-dir", mtlsDir, "-n", "alice", "-o", "CertDX E2E"); err != nil {
+		t.Fatalf("make-client with --mtls-dir: %s\n%s", err, out)
+	}
+
+	assertMTLSLayout(t, mtlsDir, "alice")
+	if _, err := os.Stat(filepath.Join(cwd, "mtls")); !os.IsNotExist(err) {
+		t.Fatalf("cwd mtls dir exists after --mtls-dir override: %v", err)
+	}
+}
+
 func containsAll(haystack, needles []string) bool {
 	set := map[string]struct{}{}
 	for _, h := range haystack {
@@ -83,4 +138,35 @@ func containsAll(haystack, needles []string) bool {
 		}
 	}
 	return true
+}
+
+func assertMTLSLayout(t *testing.T, mtlsDir string, clientName string) {
+	t.Helper()
+	assertPerm(t, mtlsDir, 0o700)
+	assertPerm(t, filepath.Join(mtlsDir, "ca.pem"), 0o644)
+	assertPerm(t, filepath.Join(mtlsDir, "ca.key"), 0o600)
+	assertPerm(t, filepath.Join(mtlsDir, "server.pem"), 0o644)
+	assertPerm(t, filepath.Join(mtlsDir, "server.key"), 0o600)
+	assertPerm(t, filepath.Join(mtlsDir, clientName+".pem"), 0o644)
+	assertPerm(t, filepath.Join(mtlsDir, clientName+".key"), 0o600)
+}
+
+func assertPerm(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %s", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o; want %o", path, got, want)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %s", path, err)
+	}
+	return data
 }


### PR DESCRIPTION
## Summary

Slice 3 of the [certdx refactor](https://github.com/ParaParty/certdx/issues/25). Hardens the existing flat `mtls/` directory without changing its on-disk layout.

- adds `MTLS_DIR` and `--mtls-dir` support for `make-ca`, `make-server`, and `make-client`
- preserves the existing cwd -> executable discovery fallback when no override is set
- rejects reserved client names `ca` and `server` before any file write
- normalizes file modes: directory `0700`, certs `0644`, keys `0600`, counter data `0644`
- keeps file names/layout unchanged: `ca.pem`, `ca.key`, `counter.txt`, `server.pem`, `server.key`, `<name>.pem`, `<name>.key`

## Behavior

No change to HTTP API, gRPC SDS, Caddyfile syntax, Kubernetes annotation, cache schema, binary names, or mTLS file layout.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -tags=e2e -run 'TestTools' -count=1 ./...` under `test/e2e/` ✅
- full e2e suite: `go test -tags=e2e -count=1 -timeout=10m ./...` under `test/e2e/` ✅ (~263s)

## Refs

- Closes #28
- Parent PRD: #25

## Test plan

- [x] Reserved names `ca` / `server` fail at `make-client` time
- [x] File modes are asserted by e2e tests
- [x] `MTLS_DIR` env override writes outside cwd
- [x] `--mtls-dir` flag override writes outside cwd
- [x] Existing cwd fallback still works through the existing chain test
- [x] CI e2e green on PR
