### PR TITLE
refactor: tighten cache-entry refcount + Stop signaling (slice 4/9)

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,9 +24,13 @@ type CertDXClientDaemon struct {
 	Config    *config.ClientConfig
 	ClientOpt []CertDXHttpClientOption
 
-	certs    map[domain.Key]*watchingCert
-	wg       sync.WaitGroup
+	certs map[domain.Key]*watchingCert
+	wg    sync.WaitGroup
+
+	// stopChan is closed exactly once via stopOnce. Multiple Stop callers
+	// (signal handlers, Caddy app teardown, etc.) are safe.
 	stopChan chan struct{}
+	stopOnce sync.Once
 }
 
 type certData struct {
@@ -50,8 +54,11 @@ func WithCertificateHandlerOption(handler CertificateUpdateHandler) WatchingCert
 	}
 }
 
+// watchUpdate runs in its own goroutine and forwards cert updates to any
+// registered handlers until Stop fires. Callers must Add(1) on the wait
+// group BEFORE spawning watchUpdate; otherwise the parent goroutine could
+// race a concurrent Wait and miss the worker.
 func (c *watchingCert) watchUpdate(wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 	for {
 		select {
@@ -125,6 +132,7 @@ func (r *CertDXClientDaemon) ClientInit() {
 		cert.Stop.Store(&stop)
 
 		r.certs[domain.AsKey(c.Domains)] = cert
+		r.wg.Add(1)
 		go cert.watchUpdate(&r.wg)
 	}
 }
@@ -148,6 +156,7 @@ func (r *CertDXClientDaemon) AddCertToWatchOpt(name string, domains []string, op
 	cert.Stop.Store(&stop)
 
 	r.certs[domain.AsKey(domains)] = cert
+	r.wg.Add(1)
 	go cert.watchUpdate(&r.wg)
 
 	return nil
@@ -453,7 +462,7 @@ func (r *CertDXClientDaemon) GRPCMain() {
 }
 
 func (r *CertDXClientDaemon) Stop() {
-	close(r.stopChan)
+	r.stopOnce.Do(func() { close(r.stopChan) })
 }
 
 func (r *CertDXClientDaemon) GetCertificate(ctx context.Context, certHash domain.Key) (*tls.Certificate, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"strings"
 	"sync"
@@ -40,7 +39,12 @@ type ServerCertCacheEntry struct {
 	cert    CertT
 	mutex   sync.Mutex
 
-	Subscribing atomic.Uint64
+	// Subscribing tracks the number of consumers that have called
+	// Subscribe and not yet Released. The renewal goroutine starts on the
+	// 0→1 transition and stops on the 1→0 transition, both detected by
+	// the Add result. A signed Int64 is used so Release can express
+	// decrement as Add(-1) instead of an unsigned underflow trick.
+	Subscribing atomic.Int64
 	Updated     atomic.Pointer[chan struct{}]
 	Stop        atomic.Pointer[chan struct{}]
 }
@@ -56,7 +60,12 @@ type CertDXServer struct {
 	acme      acme.Obtainer
 	certCache ServerCertCache
 	cacheFile ServerCacheFile
-	stop      chan struct{}
+
+	// stop is closed exactly once via stopOnce. It is never reassigned,
+	// so concurrent readers (HttpSrv, SDSSrv, etc.) can safely select on
+	// it without racing the close.
+	stop     chan struct{}
+	stopOnce sync.Once
 }
 
 func MakeCertDXServer() *CertDXServer {
@@ -292,7 +301,7 @@ func (s *CertDXServer) Subscribe(c *ServerCertCacheEntry) {
 }
 
 func (s *CertDXServer) Release(c *ServerCertCacheEntry) {
-	if c.Subscribing.Add(math.MaxUint64) == 0 {
+	if c.Subscribing.Add(-1) == 0 {
 		*c.Stop.Load() <- struct{}{}
 	}
 }
@@ -301,7 +310,9 @@ func (s *CertDXServer) IsSubcribing(c *ServerCertCacheEntry) bool {
 	return c.Subscribing.Load() != 0
 }
 
+// Stop signals every server goroutine to wind down. It is safe to call
+// concurrently and from any number of callers; only the first call closes
+// the stop channel.
 func (s *CertDXServer) Stop() {
-	close(s.stop)
-	s.stop = nil
+	s.stopOnce.Do(func() { close(s.stop) })
 }


### PR DESCRIPTION
## Summary

Slice 4 of the [certdx refactor](https://github.com/ParaParty/certdx/issues/25). Three contained concurrency fixes that do not require threading `context.Context` through the run loops (slice 5 handles that):

1. **`Subscribing` refcount** — `ServerCertCacheEntry.Subscribing` was an `atomic.Uint64` with `Release` decrementing via `Add(math.MaxUint64)` (unsigned underflow as a stand-in for subtraction). Now a signed `atomic.Int64` with `Release` calling `Add(-1)`. Same semantics, intent is now obvious. Drops the `math` import.

2. **`Stop` signaling** — `CertDXServer.Stop` closed `s.stop` then assigned `s.stop = nil`. A second concurrent `Stop` or any reader holding a reference to `s.stop` racing the assignment could either close-of-nil panic or close a fresh nil. Stop is now `sync.Once`-guarded and the field is never reassigned. `CertDXClientDaemon.Stop` gets the same treatment for symmetry.

3. **`WaitGroup.Add(1)` race in `watchUpdate`** — `wg.Add(1)` was being called from inside the goroutine that `watchUpdate` was launched as. The classic Go race is that the parent could `Wait` between the `go` statement and the inner `Add`, missing the worker entirely. `Add(1)` is now hoisted to the two callers (`ClientInit` and `AddCertToWatchOpt`) before the `go` statement; `defer wg.Done()` stays inside.

## Out of scope (deferred to other slices)

- The `atomic.Pointer[chan struct{}]` swap-and-close broadcast pattern → slice 5 (#30).
- `context.Context` propagation through run loops → slice 5 (#30).
- gRPC failover state machine → slice 6 (#31).

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race -tags=e2e -count=1 -timeout=10m ./...` under `test/e2e/` ✅ — full suite passes locally with the race detector

## Refs

- Closes #29
- Parent PRD: #25
- Builds on #35 (slice 1) and #37 (slice 2)

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] Full e2e suite passes locally with `-race`
- [x] CI e2e green on PR
