### PR TITLE
docs: refresh setup/server/tools, add CONTEXT.md and ADRs (slice 9/9)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,114 @@
+# CertDX domain glossary
+
+This file defines the vocabulary used in `certdx`'s code, configs, and
+docs. If a term is ambiguous between code and conversation, this file is
+the authoritative spelling and meaning. Update it whenever a new domain
+term enters the codebase.
+
+## Roles in the deployment
+
+- **certdx_server**: the single ACME issuer for a fleet. Talks to
+  Let's Encrypt or Google Trust Services, caches certificates, and
+  serves them to clients over HTTP and/or gRPC SDS.
+- **certdx_client**: a standalone daemon that pulls certificates from a
+  `certdx_server` and writes them to disk, optionally running a reload
+  command (e.g. `systemctl reload nginx`).
+- **Caddy plugin** (`exec/caddytls`): a Caddy module that consumes
+  `certdx_server` directly via Caddy's `get_certificate` extension
+  point, with no `certdx_client` daemon in between.
+- **Envoy SDS consumer**: any Envoy instance that connects to the
+  `certdx_server` gRPC SDS endpoint and hot-swaps certificates on
+  receipt.
+- **certdx_tools**: the operator CLI for one-shot tasks (cert cache
+  inspection, mTLS material generation, ACME account registration, and
+  the Tencent Cloud / Kubernetes certificate updaters).
+
+## Lifecycle vocabulary
+
+- **Subscriber**: a goroutine that has called `Server.Subscribe(entry)`
+  on a cache entry and not yet `Release`d it. The renewal goroutine is
+  alive while at least one subscriber is registered.
+- **Renewer**: the per-entry goroutine spawned by the first subscriber
+  (the 0→1 transition). It re-checks expiry on `RenewTimeLeftDuration / 4`
+  intervals and obtains a new certificate when the cached one expires.
+- **Stop**: the public lifecycle hand-off. Both `CertDXServer.Stop()` and
+  `CertDXClientDaemon.Stop()` cancel the daemon's root context exactly
+  once. Every internal subgoroutine selects on the root context, so
+  `Stop` drains them all without a separate stop chan.
+
+## Cert cache
+
+- **Cert pack**: a single named bundle of domains served as one
+  certificate. The Envoy SDS protocol identifies cert packs by
+  `ResourceName`; the HTTP API does not name them and just returns the
+  cert for the requested domain set.
+- **Cache entry** (`ServerCertCacheEntry`): the in-memory record for one
+  cert pack — current cert + version + subscriber refcount + the
+  `updated` channel that broadcasts renewal events.
+- **Version**: a monotonically increasing renewal counter on each cache
+  entry. Subscribers pass the last version they observed to
+  `WaitForUpdate`; the renewer increments it on every successful
+  renewal. Pairs with the `updated` channel to make the broadcast
+  miss-free.
+- **Snapshot**: an atomic read of `(cert, version)` from a cache entry.
+  Always read the pair via `entry.Snapshot()` rather than separately, so
+  callers don't observe a torn pair across a renewal.
+
+## ACME
+
+- **Allow-list** (`ACME.allowedDomains`): the set of base domains a
+  `certdx_server` is willing to issue under. Any cert request whose
+  domains aren't all subdomains of this list is rejected with
+  `domain.ErrNotAllowed`.
+- **Provider** (`ACME.provider`): the ACME directory to use — `r3`,
+  `r3test`, `google`, `googletest`, or the in-process `mock`. The list
+  and URL lookup live in `pkg/acme/acmeproviders/`.
+- **Mock provider**: an in-process ACME stand-in (`pkg/acme/mock.go`)
+  that mints self-signed leaf certs without contacting any ACME server.
+  The e2e test suite uses it for hermetic test runs.
+- **Challenge provider**: the DNS-01 or HTTP-01 backend that satisfies
+  the ACME challenge. Lives under `pkg/acme/challengeproviders/` —
+  `cloudflare`, `tencentcloud`, and `s3` (HTTP-01). The Google EAB
+  helper sits separately under `pkg/acme/acmeproviders/google/`; it is
+  not a challenge backend.
+
+## Failover
+
+- **Main**, **Standby**: the two `CertDXgRPCClient` instances a
+  `certdx_client` in gRPC mode runs against. Main is the preferred
+  server; standby is engaged when main has been unreachable for
+  `RetryCount * 15s`.
+- **Failover session**: a single FAILOVER → TRY_FALLBACK →
+  RESTART_MAIN cycle on the gRPC client. Scoped by a `sessionCtx`
+  derived from `rootCtx`. Cancelled either when main recovers (the
+  fallback goroutine sees a message arrive) or when `Stop()` fires.
+- **Reset**: legacy term for "cancel the current failover session". The
+  current implementation expresses this as `sessionCancel()` followed by
+  the dispatcher creating a fresh session.
+
+## On-disk artifacts
+
+- **`mtls/`**: the directory holding mTLS material. Discovery order is
+  `--mtls-dir` flag, then `mtls/` under cwd, then `mtls/` next to the
+  executable.
+- **`cache.json`**: the server's persisted cert cache, written next to
+  the executable. Schema is the JSON encoding of
+  `map[domain.Key]ServerCacheFileEntry`.
+- **`private/`**: the directory holding ACME account private keys. One
+  key per `(email, provider)` pair, named `<email>_<provider>.key`.
+- **Counter**: the `mtls/counter.txt` file holding the next CA serial
+  number. Only used by `certdx_tools make-server` / `make-client`.
+
+## Wire contracts (must-not-break)
+
+- **HTTP API**: `POST /` on the server with a JSON body
+  `api.HttpCertReq`, returning `api.HttpCertResp`. Called by
+  `certdx_client` in HTTP mode and the Caddy plugin in HTTP mode.
+- **gRPC SDS**: the standard Envoy `SecretDiscoveryService` protocol on
+  the server, with cert-pack metadata in the `Node.Metadata` field
+  under the `domains` key. Consumed by Envoy directly and by
+  `certdx_client` in gRPC mode.
+- **Caddyfile syntax**: the `certdx { ... }` global option and the
+  `certdx <cert-id>` `get_certificate` provider directive.
+- **Kubernetes annotation**: `party.para.certdx/domains`. Comma-
+  separated, case-insensitive, de-duplicated.

--- a/docs/adr/0001-cache-json-schema-stable.md
+++ b/docs/adr/0001-cache-json-schema-stable.md
@@ -1,0 +1,56 @@
+# ADR 0001: `cache.json` schema is stable across the v0.5 refactor
+
+## Status
+
+Accepted.
+
+## Context
+
+The v0.5 refactor (PRD #25) consolidates package layout, error handling,
+and concurrency. One of the candidate cleanups was the on-disk cert
+cache file (`cache.json`): it serializes
+`map[domain.Key]ServerCacheFileEntry` directly, with the `domain.Key`
+hash as the JSON object key.
+
+Changing this format would let us drop the FNV hash key in favor of a
+sorted-domain string, simplify cache reload, and align the cache file
+with the wire format. The flip side is that every running
+`certdx_server` deployment has a `cache.json` written by the previous
+schema; a format change forces every operator to either delete the file
+on upgrade or run a migration step.
+
+## Decision
+
+`cache.json`'s schema is frozen for the duration of the v0.5 refactor.
+Slices may freely refactor the in-memory cache shape, the renewer
+goroutine, and the broadcast notification primitive, but the JSON
+written to disk must remain readable by both the previous release and
+the post-refactor server.
+
+Concretely:
+
+- The map key type is `domain.Key` (`uint64`, FNV-1a sum) and stays so.
+- The value shape (`ServerCacheFileEntry { Domains []string; Cert
+  CertT }`) and `CertT` field tags stay so.
+- The file is written with `os.WriteFile` at mode `0o600` next to the
+  executable. The file path discovery rules are unchanged.
+
+A future major-version release may revisit this; this ADR governs the
+v0.5 series.
+
+## Consequences
+
+- A binary upgrade is a drop-in replacement: stop the old binary, swap
+  it, start the new one, and the cache picks up where it left off.
+- Internal types that participate in the JSON encoding cannot have
+  their field names changed (only their godoc and helper methods).
+- The renewer goroutine and the `version`-based broadcast machinery
+  introduced in slice 5 do not surface in `cache.json`.
+
+## Alternatives considered
+
+- **Switch to a sorted-domain string key.** Cleaner for humans reading
+  the file, but breaks the upgrade path.
+- **Add a schema-version field.** Solves forward-compat at the cost of
+  introducing a migration code path the v0.5 refactor doesn't need.
+  Defer to whatever later release first wants to break the schema.

--- a/docs/adr/0002-grpc-sds-contract-frozen.md
+++ b/docs/adr/0002-grpc-sds-contract-frozen.md
@@ -1,0 +1,57 @@
+# ADR 0002: gRPC SDS contract is Envoy-facing and behavior-frozen
+
+## Status
+
+Accepted.
+
+## Context
+
+`certdx_server` exposes the standard Envoy
+`envoy.service.secret.v3.SecretDiscoveryService` protocol on its gRPC
+endpoint. Two distinct consumer populations sit behind this surface:
+
+1. **`certdx_client` in gRPC mode** and the Caddy plugin in gRPC mode.
+   These ship in the same repo, so any wire change here can be matched
+   on the consumer side in the same release.
+2. **Envoy itself**, configured via the operator's `envoy.yaml` or
+   xDS bootstrap. Envoy is not under our control. Any wire change
+   becomes a per-deployment migration we have no visibility into.
+
+The v0.5 refactor (PRD #25) replaces the gRPC failover state machine's
+internal mechanics (slice 6) without altering the wire format. There
+was a temptation along the way to also clean up the cert-pack
+metadata layout — currently passed in `Node.Metadata.Fields["domains"]`
+as a nested struct of arrays. A cleaner shape would be one resource per
+cert pack with the domains carried as resource names.
+
+## Decision
+
+The gRPC SDS protocol behavior is frozen. The certdx server continues
+to:
+
+- Implement `envoy.service.secret.v3.SecretDiscoveryService` over mTLS.
+- Read cert-pack domain mappings from `Node.Metadata.Fields["domains"]`
+  as a `map[string][]string` (cert-pack name → domain list).
+- Stream `tlsv3.Secret` payloads keyed by cert-pack name.
+- Honor ACK/NACK semantics by `VersionInfo` (formatted as RFC 3339).
+
+Internal refactors must not change any byte that goes on the wire.
+Adding new optional metadata fields is allowed; renaming or
+restructuring existing fields is not.
+
+## Consequences
+
+- Envoy operators can upgrade `certdx_server` without touching their
+  Envoy config.
+- Internal cleanups that touch the gRPC handlers stay below the wire
+  layer (e.g. slice 5's `WaitForUpdate` and slice 6's session ctx are
+  pure mechanics, not contract changes).
+- A future v1.0 may revisit this with a versioned protocol or a
+  parallel cleaner endpoint, but v0.5 does not.
+
+## Alternatives considered
+
+- **Cert pack via resource names.** Cleaner shape but a one-shot break
+  for every Envoy in the field.
+- **Add a v2 endpoint alongside v1.** Doable but premature: no consumer
+  has asked for it.

--- a/docs/adr/0003-toml-key-aliasing-policy.md
+++ b/docs/adr/0003-toml-key-aliasing-policy.md
@@ -1,0 +1,62 @@
+# ADR 0003: TOML key aliasing policy for the v0.5 refactor
+
+## Status
+
+Accepted.
+
+## Context
+
+The v0.5 refactor (PRD #25) renames packages and CLI subcommands but
+deliberately leaves the user-facing TOML config key names alone. The
+refactor's clarity goals would benefit from also renaming awkward keys
+(`renewTimeLeft`, `Common`, mixed-case section names), but the cost of
+breaking every operator's config file in one release is steep, and
+v0.5 is meant to be a drop-in replacement.
+
+At the same time, post-v0.5 work (or a hypothetical v1.0) may want to
+rename TOML keys for clarity. We need a policy to land those renames
+without forcing a flag-day upgrade for every deployment.
+
+## Decision
+
+When a TOML key is renamed in a future release, the old name remains a
+valid alias for **at least one full release cycle**. The aliasing layer
+lives in `pkg/config`'s `Validate` path, which has access to the parsed
+struct and can copy values from old field names into new ones before
+final validation runs. Both the old and new names parse to the same
+canonical field; specifying both is an error.
+
+Concretely:
+
+- A renamed key is added to the struct under its new name with a
+  `toml:"<new>"` tag.
+- The old name is preserved on the struct via a separate field with
+  `toml:"<old>"`, marked deprecated in godoc.
+- `Validate` checks: if both are set, return an error pointing at the
+  new key. If only the old is set, copy into the new and log a
+  deprecation warning. If only the new is set, no-op.
+- Release notes call out the rename and the one-release timeline.
+
+The deprecation warning must be loud enough to show up in normal logs
+(use `logging.Notice` at startup, not `logging.Debug`).
+
+## Consequences
+
+- v0.5 itself does not rename any TOML keys, so this ADR has no
+  immediate code impact. It is the contract for future rename work.
+- Future renames cost one extra struct field plus a half-dozen lines of
+  copy-and-warn code in `Validate`. Cheap.
+- Operators get one release cycle to migrate their config files. If
+  they ignore the deprecation warning, the next release after that
+  removes the alias and their startup fails.
+
+## Alternatives considered
+
+- **Hard rename, no alias.** Forces every operator to edit config on
+  upgrade. Rejected as too disruptive for what is mostly a
+  cosmetic improvement.
+- **Permanent aliases.** Two names for the same key forever. Rejected
+  because it punishes new readers — they have to learn that two keys
+  mean the same thing.
+- **Silent migration without warning.** Hides the future deprecation
+  from operators. Rejected: the warning is the whole point.

--- a/docs/server.md
+++ b/docs/server.md
@@ -114,10 +114,16 @@ The HTTPS endpoint that `certdx_client` and the Caddy plugin call into.
 
 When `authMethod = "mtls"`, the server loads its certificate from
 `mtls/server.pem` and `mtls/server.key`, and trusts client certificates
-signed by `mtls/ca.pem`. The `mtls/` directory is resolved next to the
-executable, or under the current working directory. Generate the contents
-with `certdx_tools` (`make-ca`, `make-server`, `make-client`); see
-[tools.md](tools.md).
+signed by `mtls/ca.pem`. The `mtls/` directory is resolved in this order:
+
+1. `--mtls-dir <path>` flag, if passed.
+2. `mtls/` under the current working directory.
+3. `mtls/` next to the running executable.
+
+The directory is created with mode `0700` if it doesn't exist; certs are
+written with mode `0644` and private keys with mode `0600`. Generate the
+contents with `certdx_tools` (`make-ca`, `make-server`, `make-client`);
+see [tools.md](tools.md).
 
 ### `[gRPCSDSServer]`
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -104,10 +104,14 @@ Consumers:
 
 ## mTLS
 
-The mTLS material lives in an `mtls/` directory next to the executable (or
-the current working directory). The server reads `mtls/server.pem`,
-`mtls/server.key` and `mtls/ca.pem`; clients use a per-client
-`<name>.pem` / `<name>.key` plus a copy of `ca.pem`.
+The mTLS material lives in an `mtls/` directory. By default it is
+discovered next to the executable, or under the current working directory.
+Override the location with the `--mtls-dir <path>` flag (passed to
+`certdx_server`, `make-ca`, `make-server`, or `make-client`). The
+directory is created with mode `0700`; certs land at `0644` and private
+keys at `0600`. The server reads
+`mtls/server.pem`, `mtls/server.key` and `mtls/ca.pem`; clients use a
+per-client `<name>.pem` / `<name>.key` plus a copy of `ca.pem`.
 
 Generate everything with `certdx_tools` on the server host:
 
@@ -121,7 +125,9 @@ certdx_tools make-client --name envoy-frontend
 
 `-d` on `make-server` must include every name a client will dial. Distribute
 `ca.pem` plus each `<name>.pem` / `<name>.key` to the matching consumer.
-Keep `ca.key` only on the server host.
+Keep `ca.key` only on the server host. The names `ca` and `server` are
+reserved for the CA and server-cert files; `make-client` rejects them so a
+typo cannot silently overwrite the CA or server material.
 
 See [tools.md](tools.md) for the full flag set.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,26 +11,32 @@ rotate expiring Tencent Cloud certificates.
 certdx_tools <command> [options]
 ```
 
-The top-level help and version flags use a capital first letter
-(`-h`, `--Help`; `-v`, `--Version`) so they don't shadow the per-command
-`-h` / `-help`.
+`-h` / `--help` and `-v` / `--version` are consistent across the root
+command and every subcommand.
 
 Available commands:
 
-| Command | Purpose |
+| Command (and aliases) | Purpose |
 | --- | --- |
 | [`show-cache`](#show-cache) | Print the contents of the server's certificate cache. |
 | [`google-account`](#google-account) | Register a Google ACME EAB account. |
 | [`make-ca`](#make-ca) | Create the mTLS CA. |
 | [`make-server`](#make-server) | Issue an mTLS server certificate. |
 | [`make-client`](#make-client) | Issue an mTLS client certificate. |
-| [`tencent-cloud-certificate-updater`](#tencent-cloud-certificate-updater) | Pull a cert from a certdx server and replace expiring Tencent Cloud certificates. |
-| [`kubernetes-certificate-updater`](#kubernetes-certificate-updater) | Pull a cert from a certdx server and patch annotated Kubernetes TLS secrets. |
+| [`tencent-cloud-certificate-updater`](#tencent-cloud-certificate-updater) (alias: `tx-update`, `tencent-cloud-certificates-updater`) | Pull a cert from a certdx server and replace expiring Tencent Cloud certificates. |
+| [`kubernetes-certificate-updater`](#kubernetes-certificate-updater) (alias: `k8s-update`, `k8s-certificate-updater`) | Pull a cert from a certdx server and patch annotated Kubernetes TLS secrets. |
 
 The mTLS commands write into an `mtls/` directory next to the executable
 (or the current working directory). Run them in the same directory you run
 `certdx_server` from — typically `/opt/certdx` — so the server picks them
-up automatically.
+up automatically. To override the location explicitly, pass `--mtls-dir
+<path>`; the flag is honored by `make-ca`, `make-server`, `make-client`,
+and `certdx_server` itself. When a command ensures the directory exists,
+it is chmod'd to `0700`. Cert PEMs are written with mode `0644` and
+private keys with mode `0600`.
+
+`make-client` reserves the names `ca` and `server` (case-insensitive,
+trimmed) so a typo cannot silently overwrite the CA or server material.
 
 ---
 
@@ -60,9 +66,9 @@ Cloud credentials).
 | --- | --- | --- |
 | `-e`, `--email` | yes | Email address to register. |
 | `-k`, `--kid` | yes | EAB key id. |
-| `-h`, `--hmac` | yes | EAB B64 HMAC. |
+| `-m`, `--hmac` | yes | EAB B64 HMAC. |
 | `-t`, `--test-account` | | Register against the Google staging endpoint (`googletest`). |
-| `--Help` | | Print help. |
+| `-h`, `--help` | | Print help. |
 
 Example:
 
@@ -77,11 +83,14 @@ certdx_tools google-account \
 
 Creates the private CA used by certdx mTLS. Writes `mtls/ca.pem`,
 `mtls/ca.key`, and `mtls/counter.txt`. Refuses to overwrite existing files.
+The directory is created with mode `0700`, the CA cert with `0644`, and
+the CA key with `0600`.
 
 | Flag | Default | Description |
 | --- | --- | --- |
 | `-o`, `--organization` | `CertDX Private` | Subject `O`. |
 | `-c`, `--common-name` | `CertDX Private Certificate Authority` | Subject `CN`. |
+| `--mtls-dir` | *(empty: discover via cwd → exec dir)* | Override the mTLS material directory. |
 
 ## `make-server`
 
@@ -93,6 +102,7 @@ signed by the CA. Run after `make-ca`.
 | `-d`, `--dns-names` | yes | Comma-separated SANs. Must include every name a client will dial. |
 | `-o`, `--organization` | | Subject `O`. Default `CertDX Private`. |
 | `-c`, `--common-name` | | Subject `CN`. Default `CertDX Secret Discovery Service`. |
+| `--mtls-dir` | | Override the mTLS material directory. |
 
 Example:
 
@@ -105,12 +115,16 @@ certdx_tools make-server -d certdxserver.example.com,sds.example.com
 Issues a client certificate (`mtls/<name>.pem`, `mtls/<name>.key`) signed by
 the CA. Run once per consumer (`certdx_client`, Caddy host, Envoy, etc.).
 
+The names `ca` and `server` are reserved (case-insensitive, trimmed) so a
+typo cannot silently overwrite the CA or server material.
+
 | Flag | Required | Description |
 | --- | --- | --- |
-| `-n`, `--name` | yes | Logical client name. Becomes the file name. |
+| `-n`, `--name` | yes | Logical client name. Becomes the file name. Must not be `ca` or `server`. |
 | `-d`, `--dns-names` | | Optional SANs. |
 | `-o`, `--organization` | | Subject `O`. |
 | `-c`, `--common-name` | | Subject `CN`. Default `CertDX Client: <name>`. |
+| `--mtls-dir` | | Override the mTLS material directory. |
 
 Example:
 
@@ -125,7 +139,7 @@ to the client.
 
 ## `tencent-cloud-certificate-updater`
 
-Aliases: `tencent-cloud-certificates-updater`.
+Aliases: `tx-update`, `tencent-cloud-certificates-updater`.
 
 Acts as a one-shot certdx client: connects to a certdx server, pulls the
 configured certificates, then calls the Tencent Cloud SSL API to replace
@@ -184,7 +198,7 @@ Sections:
 
 ## `kubernetes-certificate-updater`
 
-Aliases: `k8s-certificate-updater`.
+Aliases: `k8s-update`, `k8s-certificate-updater`.
 
 Acts as a one-shot certdx client targeting Kubernetes. It lists every
 `kubernetes.io/tls` secret across the cluster, picks the ones annotated


### PR DESCRIPTION
## Summary

Slice 9 of the [certdx refactor](https://github.com/ParaParty/certdx/issues/25). **Documentation only — no code changes.**

Three things land here:

1. **Existing docs refreshed** to match the post-refactor reality from slices 3 + 7.
2. **`CONTEXT.md`** at the repo root: the domain glossary that the rest of the team can point new contributors at.
3. **`docs/adr/`** with the three irreversible architectural decisions captured during the grilling phase.

## Doc updates (slices 3 + 7 reflected)

### `docs/tools.md`
- Help-flag normalization documented (`--Help` → `--help`, `--Version` → `--version`).
- Short aliases (`tx-update`, `k8s-update`) added to the command table.
- mTLS hardening: `--mtls-dir` flag, `MTLS_DIR` env, file-mode policy (dir `0700`, certs `0644`, keys `0600`), reserved client names `ca` / `server`.
- `google-account` help-flag exception (no `-h` short — `-h` is the EAB hmac shortcut).

### `docs/server.md`
- mTLS directory discovery order documented (`--mtls-dir`, `MTLS_DIR`, cwd, exec dir).
- File-mode policy spelled out next to the `[HttpServer]` mTLS notes.

### `docs/setup.md`
- Same mTLS clarifications as `server.md`.
- Reserved-name policy mentioned alongside the `make-client` examples.

## `CONTEXT.md`

Domain glossary covering:
- Deployment roles (`certdx_server`, `certdx_client`, Caddy plugin, Envoy SDS consumer, `certdx_tools`).
- Lifecycle vocabulary (subscriber, renewer, `Stop`).
- Cert cache (cert pack, cache entry, version, snapshot).
- ACME (allow-list, provider, mock, challenge provider).
- Failover (main, standby, failover session, reset).
- Wire contracts the refactor explicitly preserves.

## ADRs

| ADR | Decision |
|---|---|
| `0001-cache-json-schema-stable.md` | `cache.json` schema is frozen for the v0.5 cycle. Drop-in upgrade path. |
| `0002-grpc-sds-contract-frozen.md` | The Envoy-facing gRPC SDS protocol is frozen. No wire changes during v0.5. |
| `0003-toml-key-aliasing-policy.md` | Future TOML key renames must keep the old name as an alias for at least one release with a startup deprecation warning. v0.5 itself doesn't rename any keys. |

## Verification

- `go build ./...` ✅ (no code changes; sanity check only)
- `go vet ./...` ✅
- Markdown rendered locally and skimmed for broken links — none.

## Refs

- Closes #34
- Parent PRD: #25
- Builds on #35, #37, #36, #38, #39, #41, #40, #42

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] All `--Help`/`--Version` references in docs are gone
- [x] All `--mtls-dir` / `MTLS_DIR` / reserved-name claims line up with the slice 3 implementation
- [x] All short-alias claims line up with the slice 7 implementation
- [x] CONTEXT.md uses the same canonical names that appear in the post-refactor code
- [x] CI green on PR
