### PR TITLE
refactor: simplify txc updater set helpers

### DIFF
--- a/exec/tools/tasks/txcCertificateUpdater/util.go
+++ b/exec/tools/tasks/txcCertificateUpdater/util.go
@@ -1,54 +1,49 @@
 package txcCertificateUpdater
 
-func isSameStrSetRejectNilItem(a []*string, b []string) bool {
+func isSameStrSetIgnoringNil(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	setA := make(map[string]struct{}, len(a))
+	set := make(map[string]struct{}, len(a))
 	for _, v := range a {
-		if v == nil {
-			return false
-		}
-		setA[*v] = struct{}{}
+		set[v] = struct{}{}
 	}
-	setB := make(map[string]struct{}, len(b))
 	for _, v := range b {
-		setB[v] = struct{}{}
-	}
-
-	for key := range setA {
-		if _, ok := setB[key]; !ok {
+		if _, ok := set[v]; !ok {
 			return false
 		}
 	}
 	return true
 }
 
-func isSameStrSetRejectNilItemPtrArrPtrArr(a []*string, b []*string) bool {
-	if len(a) != len(b) {
+func derefAll(in []*string) ([]string, bool) {
+	out := make([]string, len(in))
+	for i, v := range in {
+		if v == nil {
+			return nil, false
+		}
+		out[i] = *v
+	}
+	return out, true
+}
+
+func isSameStrSetRejectNilItem(a []*string, b []string) bool {
+	deref, ok := derefAll(a)
+	if !ok {
 		return false
 	}
+	return isSameStrSetIgnoringNil(deref, b)
+}
 
-	setA := make(map[string]struct{}, len(a))
-	for _, v := range a {
-		if v == nil {
-			return false
-		}
-		setA[*v] = struct{}{}
+func isSameStrSetRejectNilItemPtrArrPtrArr(a []*string, b []*string) bool {
+	derefA, ok := derefAll(a)
+	if !ok {
+		return false
 	}
-	setB := make(map[string]struct{}, len(b))
-	for _, v := range b {
-		if v == nil {
-			return false
-		}
-		setB[*v] = struct{}{}
+	derefB, ok := derefAll(b)
+	if !ok {
+		return false
 	}
-
-	for key := range setA {
-		if _, ok := setB[key]; !ok {
-			return false
-		}
-	}
-	return true
+	return isSameStrSetIgnoringNil(derefA, derefB)
 }

--- a/exec/tools/tasks/txcCertificateUpdater/util_test.go
+++ b/exec/tools/tasks/txcCertificateUpdater/util_test.go
@@ -1,0 +1,31 @@
+package txcCertificateUpdater
+
+import "testing"
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestIsSameStrSetRejectNilItem(t *testing.T) {
+	if !isSameStrSetRejectNilItem([]*string{ptr("b"), ptr("a")}, []string{"a", "b"}) {
+		t.Fatal("expected equal sets with different order")
+	}
+	if isSameStrSetRejectNilItem([]*string{ptr("a"), ptr("b")}, []string{"a", "c"}) {
+		t.Fatal("expected different sets")
+	}
+	if isSameStrSetRejectNilItem([]*string{ptr("a"), nil}, []string{"a", "b"}) {
+		t.Fatal("expected nil item to reject")
+	}
+}
+
+func TestIsSameStrSetRejectNilItemPtrArrPtrArr(t *testing.T) {
+	if !isSameStrSetRejectNilItemPtrArrPtrArr([]*string{ptr("b"), ptr("a")}, []*string{ptr("a"), ptr("b")}) {
+		t.Fatal("expected equal sets with different order")
+	}
+	if isSameStrSetRejectNilItemPtrArrPtrArr([]*string{ptr("a"), ptr("b")}, []*string{ptr("a"), ptr("c")}) {
+		t.Fatal("expected different sets")
+	}
+	if isSameStrSetRejectNilItemPtrArrPtrArr([]*string{ptr("a"), ptr("b")}, []*string{ptr("a"), nil}) {
+		t.Fatal("expected nil item to reject")
+	}
+}


### PR DESCRIPTION
## Summary

- extract `derefAll` for Tencent Cloud SDK `[]*string` handling
- centralize string-set comparison in one helper
- add focused tests for order-insensitive comparison, mismatch, and nil rejection

## Verification

- `go test ./tasks/txcCertificateUpdater` in `exec/tools`
- `go test ./...` in `exec/tools`
- `go build ./...` at repo root
- `go vet ./...` at repo root
- `go build ./...` in `exec/tools`
- `go vet ./...` in `exec/tools`
- `go test -tags=e2e ./...` in `test/e2e`

Slock task #3.
