### PR TITLE
refactor: extract cli.LoadTOML helper

### DIFF
--- a/exec/server/main.go
+++ b/exec/server/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"io"
 	"os"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	flag "github.com/spf13/pflag"
 	"pkg.para.party/certdx/pkg/cli"
 	"pkg.para.party/certdx/pkg/logging"
@@ -53,22 +51,11 @@ func init() {
 
 	cdxsrv = server.MakeCertDXServer()
 
-	cfile, err := os.Open(*pConf)
-	if err != nil {
-		logging.Fatal("Open config file failed, err: %s", err)
-	}
-	defer cfile.Close()
-	if b, err := io.ReadAll(cfile); err == nil {
-		if err := toml.Unmarshal(b, &cdxsrv.Config); err == nil {
-			logging.Info("Config loaded")
-		} else {
-			logging.Fatal("Unmarshaling config failed, err: %s", err)
-		}
-	} else {
-		logging.Fatal("Reading config file failed, err: %s", err)
+	if err := cli.LoadTOML(*pConf, &cdxsrv.Config); err != nil {
+		logging.Fatal("%s", err)
 	}
 
-	if err = cdxsrv.Config.Validate(); err != nil {
+	if err := cdxsrv.Config.Validate(); err != nil {
 		logging.Fatal("Invalid config, err: %v", err)
 	}
 

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/BurntSushi/toml"
+
+	"pkg.para.party/certdx/pkg/logging"
+)
+
+// LoadTOML reads a TOML file at path and unmarshals it into target.
+// Wraps every step's error with the file path so the caller can log a
+// single line and exit. Logs an info message on success.
+//
+// target must be a non-nil pointer to a struct (or any other type
+// supported by the TOML decoder).
+func LoadTOML(path string, target any) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open config %q: %w", path, err)
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("read config %q: %w", path, err)
+	}
+	if err := toml.Unmarshal(b, target); err != nil {
+		return fmt.Errorf("parse config %q: %w", path, err)
+	}
+	logging.Info("Config loaded from %s", path)
+	return nil
+}


### PR DESCRIPTION
## Summary

Follow-up C from the [main-refactor](https://github.com/ParaParty/certdx/tree/main-refactor) comparison, closes task #6.

Adds `pkg/cli/config.go` with `LoadTOML(path, target)`: a one-call helper that opens, reads, and unmarshals a TOML config file with every error wrapped to include the file path. Logs a single info line on success.

`exec/server/main.go` uses it. The previous nested-if open/read/unmarshal ladder collapses to:

```go
if err := cli.LoadTOML(*pConf, &cdxsrv.Config); err != nil {
    logging.Fatal("%s", err)
}
```

## Stacking

This branch is **stacked on `refactor/pkg-cli-helpers`** (PR #45, task #4). Once that PR merges, this rebases cleanly onto main.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race -tags=e2e -count=1 -timeout=10m ./...` under `test/e2e/` ✅ (~262s)

## Refs

- Closes task #6
- Stacked on PR #45
- Builds on the merged 9-slice refactor (#25)

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] Full e2e suite passes locally with `-race`
- [ ] CI green on PR
