### PR TITLE
refactor: extract cli.LoadTOML, use in server main + client daemon

### DIFF
--- a/exec/server/main.go
+++ b/exec/server/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"io"
 	"os"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	flag "github.com/spf13/pflag"
 	"pkg.para.party/certdx/pkg/cli"
 	"pkg.para.party/certdx/pkg/logging"
@@ -53,22 +51,11 @@ func init() {
 
 	cdxsrv = server.MakeCertDXServer()
 
-	cfile, err := os.Open(*pConf)
-	if err != nil {
-		logging.Fatal("Open config file failed, err: %s", err)
-	}
-	defer cfile.Close()
-	if b, err := io.ReadAll(cfile); err == nil {
-		if err := toml.Unmarshal(b, &cdxsrv.Config); err == nil {
-			logging.Info("Config loaded")
-		} else {
-			logging.Fatal("Unmarshaling config failed, err: %s", err)
-		}
-	} else {
-		logging.Fatal("Reading config file failed, err: %s", err)
+	if err := cli.LoadTOML(*pConf, &cdxsrv.Config); err != nil {
+		logging.Fatal("%s", err)
 	}
 
-	if err = cdxsrv.Config.Validate(); err != nil {
+	if err := cdxsrv.Config.Validate(); err != nil {
 		logging.Fatal("Invalid config, err: %v", err)
 	}
 

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/BurntSushi/toml"
+
+	"pkg.para.party/certdx/pkg/logging"
+)
+
+// LoadTOML reads a TOML file at path and unmarshals it into target.
+// Wraps every step's error with the file path so the caller can log a
+// single line and exit. Logs an info message on success.
+//
+// target must be a non-nil pointer to a struct (or any other type
+// supported by the TOML decoder).
+func LoadTOML(path string, target any) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open config %q: %w", path, err)
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("read config %q: %w", path, err)
+	}
+	if err := toml.Unmarshal(b, target); err != nil {
+		return fmt.Errorf("parse config %q: %w", path, err)
+	}
+	logging.Info("Config loaded from %s", path)
+	return nil
+}

--- a/pkg/client/daemon.go
+++ b/pkg/client/daemon.go
@@ -17,12 +17,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 	"sync/atomic"
 
-	"github.com/BurntSushi/toml"
+	"pkg.para.party/certdx/pkg/cli"
 	"pkg.para.party/certdx/pkg/config"
 	"pkg.para.party/certdx/pkg/domain"
 	"pkg.para.party/certdx/pkg/logging"
@@ -210,22 +209,9 @@ func (r *CertDXClientDaemon) startWatchers() {
 // LoadConfigurationAndValidateOpt parses the TOML file at path into the
 // daemon's config and runs Validate with the supplied options.
 func (r *CertDXClientDaemon) LoadConfigurationAndValidateOpt(path string, options []config.ValidatingOption) error {
-	cfile, err := os.Open(path)
-	if err != nil {
-		logging.Fatal("Open config file failed, err: %s", err)
+	if err := cli.LoadTOML(path, r.Config); err != nil {
 		return err
 	}
-	defer cfile.Close()
-	if b, err := io.ReadAll(cfile); err == nil {
-		if err := toml.Unmarshal(b, r.Config); err == nil {
-			logging.Info("Config loaded")
-		} else {
-			logging.Fatal("Unmarshalling config failed, err: %s", err)
-		}
-	} else {
-		logging.Fatal("Reading config file failed, err: %s", err)
-	}
-
 	return r.Config.Validate(options)
 }
 


### PR DESCRIPTION
## Summary

Follow-up C from the [main-refactor](https://github.com/ParaParty/certdx/tree/main-refactor) comparison, closes task 6. Re-opens [#48](https://github.com/ParaParty/certdx/pull/48) which was auto-closed when its base branch (`refactor/pkg-cli-helpers`) was deleted after merging.

## What landed

- New **`pkg/cli/config.go`** with `LoadTOML(path, target)`: opens, reads, and unmarshals a TOML file with every error wrapped to include the file path. Logs an info line on success.
- **`exec/server/main.go`** uses it. Open/Read/Unmarshal ladder collapses to one call.
- **`pkg/client/daemon.go`** `LoadConfigurationAndValidateOpt` also routed through `cli.LoadTOML` per @LDLDL's review note. Drops three `logging.Fatal` calls from library code (now returns wrapped errors), drops the `io` and `toml` imports from the daemon.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race -tags=e2e -count=1 -timeout=10m ./...` under `test/e2e/` ✅ (~263s)

## Refs

- Closes task #6
- Replaces #48
- Builds on the merged 9-slice refactor (#25) + #45 + #47

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] Full e2e suite passes locally with `-race`
- [x] CI green on PR
