### PR TITLE
refactor: normalize domain allow-list checks

### DIFF
--- a/docs/adr/0001-cache-json-schema-stable.md
+++ b/docs/adr/0001-cache-json-schema-stable.md
@@ -29,7 +29,10 @@ the post-refactor server.
 
 Concretely:
 
-- The map key type is `domain.Key` (`uint64`, FNV-1a sum) and stays so.
+- The map key type is `domain.Key` (`uint64`) and stays so. The v0.5
+  refactor canonicalizes input domains before hashing: lower-case, strip
+  trailing root dots, drop empty values, de-duplicate, sort, then FNV-1a
+  the NUL-separated domain list.
 - The value shape (`ServerCacheFileEntry { Domains []string; Cert
   CertT }`) and `CertT` field tags stay so.
 - The file is written with `os.WriteFile` at mode `0o600` next to the

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -8,6 +8,7 @@ package domain
 import (
 	"errors"
 	"hash/fnv"
+	"sort"
 	"strings"
 )
 
@@ -21,26 +22,40 @@ var ErrNotAllowed = errors.New("domain not allowed")
 // to use as a map key for cert-cache lookups.
 type Key uint64
 
-// AsKey hashes a slice of domain names into a Key. The hash is order-
-// insensitive: AsKey([]string{"a", "b"}) == AsKey([]string{"b", "a"}).
+// AsKey hashes a slice of domain names into a Key. The input is canonicalized
+// before hashing, so case, trailing root dots, duplicates, and input order do
+// not affect the result.
 func AsKey(domains []string) Key {
-	var h uint64 = 0
+	canon := make([]string, 0, len(domains))
+	seen := make(map[string]struct{}, len(domains))
 	for _, d := range domains {
-		hf := fnv.New64a()
-		hf.Write([]byte(d))
-		h += hf.Sum64()
+		d = normalizeName(d)
+		if d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		canon = append(canon, d)
 	}
-	return Key(h)
+	sort.Strings(canon)
+
+	h := fnv.New64a()
+	h.Write([]byte(strings.Join(canon, "\x00")))
+	return Key(h.Sum64())
 }
 
 // IsSubdomain reports whether domain is one of allowedDomains, or a subdomain
-// of any of them. Exact matches and dot-prefixed suffix matches both count.
+// of any of them. Matching is case-insensitive and ignores a trailing root dot.
 func IsSubdomain(domain string, allowedDomains []string) bool {
+	d := normalizeName(domain)
 	for _, allowedDomain := range allowedDomains {
-		if allowedDomain == domain {
+		parent := normalizeName(allowedDomain)
+		if d == parent {
 			return true
 		}
-		if strings.HasSuffix(domain, "."+allowedDomain) {
+		if strings.HasSuffix(d, "."+parent) {
 			return true
 		}
 	}
@@ -62,4 +77,8 @@ func AllAllowed(allowedList []string, toCheck []string) bool {
 // IsSubdomain.
 func Allowed(allowedList []string, toCheck string) bool {
 	return IsSubdomain(toCheck, allowedList)
+}
+
+func normalizeName(name string) string {
+	return strings.ToLower(strings.TrimSuffix(name, "."))
 }

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -1,0 +1,59 @@
+package domain
+
+import "testing"
+
+func TestIsSubdomainNormalizesCaseAndRootDot(t *testing.T) {
+	allowed := []string{"Example.COM."}
+
+	for _, domain := range []string{
+		"example.com",
+		"EXAMPLE.com.",
+		"api.example.com",
+		"API.EXAMPLE.COM.",
+	} {
+		if !IsSubdomain(domain, allowed) {
+			t.Fatalf("expected %q to be allowed by %v", domain, allowed)
+		}
+	}
+}
+
+func TestIsSubdomainRequiresLabelBoundary(t *testing.T) {
+	allowed := []string{"evil.com"}
+
+	for _, domain := range []string{
+		"attackerevil.com",
+		"sub.attackerevil.com",
+		"evil.com.attacker.net",
+	} {
+		if IsSubdomain(domain, allowed) {
+			t.Fatalf("expected %q to be rejected by %v", domain, allowed)
+		}
+	}
+}
+
+func TestAllAllowedUsesNormalizedSubdomainRules(t *testing.T) {
+	allowed := []string{"Example.COM."}
+	toCheck := []string{"example.com", "API.EXAMPLE.COM."}
+
+	if !AllAllowed(allowed, toCheck) {
+		t.Fatalf("expected %v to be allowed by %v", toCheck, allowed)
+	}
+}
+
+func TestAsKeyCanonicalizesDomainSets(t *testing.T) {
+	first := AsKey([]string{"API.Example.COM.", "example.com", "api.example.com"})
+	second := AsKey([]string{"example.com.", "api.example.com"})
+
+	if first != second {
+		t.Fatalf("expected equivalent domain sets to hash to the same key: %d != %d", first, second)
+	}
+}
+
+func TestAsKeyKeepsDistinctDomainSetsDistinct(t *testing.T) {
+	first := AsKey([]string{"a.example.com", "bc.example.com"})
+	second := AsKey([]string{"ab.example.com", "c.example.com"})
+
+	if first == second {
+		t.Fatalf("expected distinct domain sets to hash to different keys: %d", first)
+	}
+}


### PR DESCRIPTION
## summary
- port the useful `pkg/utils/domain.go` behavior from `main-refactor`
- make `domain.IsSubdomain` case-insensitive and tolerant of trailing root dots
- make `domain.AsKey` canonicalize lower-case/trailing-dot/empty/duplicate/order differences before hashing
- add focused tests for normalized allow-list matching, label-boundary rejection, and canonical cache keys
- update ADR-0001 so the cache-key algorithm docs match the ported behavior

## verification
- `go test ./pkg/domain`
- `git diff --check`
- `go build ./...`
- `go vet ./...`
