### PR TITLE
refactor: clean up caddytls module wiring

### DIFF
--- a/exec/caddytls/caddyfile.go
+++ b/exec/caddytls/caddyfile.go
@@ -6,154 +6,150 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+
 	"pkg.para.party/certdx/pkg/config"
 )
 
+const (
+	dirCertDX            = "certdx"
+	dirRetryCount        = "retry_count"
+	dirMode              = "mode"
+	dirReconnectInterval = "reconnect_interval"
+	dirHTTP              = "http"
+	dirGRPC              = "GRPC"
+	dirCertificate       = "certificate"
+
+	dirMainServer    = "main_server"
+	dirStandbyServer = "standby_server"
+
+	dirURL        = "url"
+	dirAuthMethod = "authMethod"
+	dirToken      = "token"
+	dirCA         = "ca"
+	dirCertFile   = "certificate"
+	dirKey        = "key"
+	dirServerAddr = "server"
+)
+
 func init() {
-	httpcaddyfile.RegisterGlobalOption("certdx", parseCertDXGlobalOptions)
+	httpcaddyfile.RegisterGlobalOption(dirCertDX, parseCertDXGlobalOptions)
 }
 
-// parseCertDXGlobalOptions configures the "certdx" global option from Caddyfile.
-func parseCertDXGlobalOptions(d *caddyfile.Dispenser, existingVal any) (any, error) {
+func expectArg1(d *caddyfile.Dispenser) (string, error) {
+	args := d.RemainingArgs()
+	if len(args) != 1 {
+		return "", d.Errf("expected 1 argument for %s, got %d", d.Val(), len(args))
+	}
+	return args[0], nil
+}
+
+// parseCertDXGlobalOptions configures the "certdx" global option.
+func parseCertDXGlobalOptions(d *caddyfile.Dispenser, _ any) (any, error) {
 	module := MakeCertDXCaddyDaemon()
 
 	for d.Next() {
 		if d.NextArg() {
-			return nil, d.Err("no argument excepted for certdx")
+			return nil, d.Errf("no argument expected for %s", dirCertDX)
 		}
 
 		for d.NextBlock(0) {
 			switch d.Val() {
-			case "retry_count":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return nil, d.Errf("expected 1 argument for retry_count, got %v", len(args))
-				}
-				v := args[0]
-				var err error
-				module.RetryCount, err = strconv.Atoi(v)
+			case dirRetryCount:
+				v, err := expectArg1(d)
 				if err != nil {
-					return nil, d.Errf("unexcepted value for retry_count: %v", v)
+					return nil, err
 				}
-			case "mode":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return nil, d.Errf("expected 1 argument for mode, got %v", len(args))
+				n, err := strconv.Atoi(v)
+				if err != nil {
+					return nil, d.Errf("invalid value for %s: %v", dirRetryCount, v)
 				}
-				v := args[0]
+				module.RetryCount = n
+			case dirMode:
+				v, err := expectArg1(d)
+				if err != nil {
+					return nil, err
+				}
 				module.Mode = v
-			case "reconnect_interval":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return nil, d.Errf("expected 1 argument for reconnect_interval, got %v", len(args))
+			case dirReconnectInterval:
+				v, err := expectArg1(d)
+				if err != nil {
+					return nil, err
 				}
-				v := args[0]
 				module.ReconnectInterval = v
-			case "http":
+			case dirHTTP:
 				if d.NextArg() {
-					return nil, d.Err("no argument expected for http")
+					return nil, d.Errf("no argument expected for %s", dirHTTP)
 				}
-				err := module.UnmarshalHttpBlock(d.NewFromNextSegment())
-				if err != nil {
-					return nil, d.Errf("unexpected unmarshaling error for http: %w", err)
+				if err := module.UnmarshalHttpBlock(d.NewFromNextSegment()); err != nil {
+					return nil, d.Errf("failed unmarshaling %s block: %v", dirHTTP, err)
 				}
-			case "GRPC":
+			case dirGRPC:
 				if d.NextArg() {
-					return nil, d.Err("no argument expected for GRPC")
+					return nil, d.Errf("no argument expected for %s", dirGRPC)
 				}
-				err := module.UnmarshalGRPCBlock(d.NewFromNextSegment())
+				if err := module.UnmarshalGRPCBlock(d.NewFromNextSegment()); err != nil {
+					return nil, d.Errf("failed unmarshaling %s block: %v", dirGRPC, err)
+				}
+			case dirCertificate:
+				certID, err := expectArg1(d)
 				if err != nil {
-					return nil, d.Errf("unexpected unmarshaling error for GRPC: %w", err)
+					return nil, err
 				}
-			case "certificate":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return nil, d.Errf("expected 1 argument for certificate, got %v", len(args))
-				}
-				cert_id := args[0]
-				err := module.UnmarshalCertificateBlock(cert_id, d.NewFromNextSegment())
-				if err != nil {
-					return nil, d.Errf("unexpected unmarshaling error for certificate: %w", err)
+				if err := module.UnmarshalCertificateBlock(certID, d.NewFromNextSegment()); err != nil {
+					return nil, d.Errf("failed unmarshaling %s block: %v", dirCertificate, err)
 				}
 			default:
-				return nil, d.Errf("unrecognized subdirective for certdx: %s", d.Val())
+				return nil, d.Errf("unrecognized subdirective for %s: %s", dirCertDX, d.Val())
 			}
 		}
 	}
 
 	return httpcaddyfile.App{
-		Name:  "certdx",
+		Name:  dirCertDX,
 		Value: caddyconfig.JSON(module, nil),
 	}, nil
 }
 
+// UnmarshalHttpBlock parses the http { ... } sub-block.
 func (c *CertDXCaddyDaemon) UnmarshalHttpBlock(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextBlock(0) {
 			switch d.Val() {
-			case "main_server":
-				err := c.UnmarshalHttpServerBlock(&c.Http.MainServer, d.NewFromNextSegment())
-				if err != nil {
+			case dirMainServer:
+				if err := c.unmarshalHttpServerBlock(&c.Http.MainServer, d.NewFromNextSegment()); err != nil {
 					return err
 				}
-			case "standby_server":
-				err := c.UnmarshalHttpServerBlock(&c.Http.StandbyServer, d.NewFromNextSegment())
-				if err != nil {
+			case dirStandbyServer:
+				if err := c.unmarshalHttpServerBlock(&c.Http.StandbyServer, d.NewFromNextSegment()); err != nil {
 					return err
 				}
 			default:
-				return d.Errf("unrecognized subdirective for http: %s", d.Val())
+				return d.Errf("unrecognized subdirective for %s: %s", dirHTTP, d.Val())
 			}
 		}
 	}
 	return nil
 }
 
-func (c *CertDXCaddyDaemon) UnmarshalHttpServerBlock(s *config.ClientHttpServer, d *caddyfile.Dispenser) error {
+func (c *CertDXCaddyDaemon) unmarshalHttpServerBlock(s *config.ClientHttpServer, d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextBlock(0) {
+			v, err := expectArg1(d)
+			if err != nil {
+				return err
+			}
 			switch d.Val() {
-			case "url":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for url, got %v", len(args))
-				}
-				v := args[0]
+			case dirURL:
 				s.Url = v
-			case "authMethod":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for token, got %v", len(args))
-				}
-				v := args[0]
+			case dirAuthMethod:
 				s.AuthMethod = v
-			case "token":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for token, got %v", len(args))
-				}
-				v := args[0]
+			case dirToken:
 				s.Token = v
-			case "ca":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for ca, got %v", len(args))
-				}
-				v := args[0]
+			case dirCA:
 				s.CA = v
-			case "certificate":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for certificate, got %v", len(args))
-				}
-				v := args[0]
+			case dirCertFile:
 				s.Certificate = v
-			case "key":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for key, got %v", len(args))
-				}
-				v := args[0]
+			case dirKey:
 				s.Key = v
 			default:
 				return d.Errf("unrecognized subdirective for http server: %s", d.Val())
@@ -163,18 +159,17 @@ func (c *CertDXCaddyDaemon) UnmarshalHttpServerBlock(s *config.ClientHttpServer,
 	return nil
 }
 
+// UnmarshalGRPCBlock parses the GRPC { ... } sub-block.
 func (c *CertDXCaddyDaemon) UnmarshalGRPCBlock(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextBlock(0) {
 			switch d.Val() {
-			case "main_server":
-				err := c.UnmarshalGRPCServerBlock(&c.GRPC.MainServer, d.NewFromNextSegment())
-				if err != nil {
+			case dirMainServer:
+				if err := c.unmarshalGRPCServerBlock(&c.GRPC.MainServer, d.NewFromNextSegment()); err != nil {
 					return err
 				}
-			case "standby_server":
-				err := c.UnmarshalGRPCServerBlock(&c.GRPC.StandbyServer, d.NewFromNextSegment())
-				if err != nil {
+			case dirStandbyServer:
+				if err := c.unmarshalGRPCServerBlock(&c.GRPC.StandbyServer, d.NewFromNextSegment()); err != nil {
 					return err
 				}
 			default:
@@ -185,37 +180,21 @@ func (c *CertDXCaddyDaemon) UnmarshalGRPCBlock(d *caddyfile.Dispenser) error {
 	return nil
 }
 
-func (c *CertDXCaddyDaemon) UnmarshalGRPCServerBlock(s *config.ClientGRPCServer, d *caddyfile.Dispenser) error {
+func (c *CertDXCaddyDaemon) unmarshalGRPCServerBlock(s *config.ClientGRPCServer, d *caddyfile.Dispenser) error {
 	for d.Next() {
 		for d.NextBlock(0) {
+			v, err := expectArg1(d)
+			if err != nil {
+				return err
+			}
 			switch d.Val() {
-			case "server":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for server, got %v", len(args))
-				}
-				v := args[0]
+			case dirServerAddr:
 				s.Server = v
-			case "ca":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for ca, got %v", len(args))
-				}
-				v := args[0]
+			case dirCA:
 				s.CA = v
-			case "certificate":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for certificate, got %v", len(args))
-				}
-				v := args[0]
+			case dirCertFile:
 				s.Certificate = v
-			case "key":
-				args := d.RemainingArgs()
-				if len(args) != 1 {
-					return d.Errf("expected 1 argument for key, got %v", len(args))
-				}
-				v := args[0]
+			case dirKey:
 				s.Key = v
 			default:
 				return d.Errf("unrecognized subdirective for grpc server: %s", d.Val())
@@ -225,19 +204,16 @@ func (c *CertDXCaddyDaemon) UnmarshalGRPCServerBlock(s *config.ClientGRPCServer,
 	return nil
 }
 
-func (c *CertDXCaddyDaemon) UnmarshalCertificateBlock(cert_id string, d *caddyfile.Dispenser) error {
+// UnmarshalCertificateBlock collects the domain list under one certificate block.
+func (c *CertDXCaddyDaemon) UnmarshalCertificateBlock(certID string, d *caddyfile.Dispenser) error {
 	var domains []string
-
 	for d.Next() {
 		for d.NextBlock(0) {
 			domains = append(domains, d.Val())
 		}
 	}
-
-	if len(domains) <= 0 {
-		return d.Err("no domains present in certificate definition")
+	if err := c.CertificateDefs.Add(certID, domains); err != nil {
+		return d.Err(err.Error())
 	}
-
-	c.CertificateDefs[cert_id] = domains
 	return nil
 }

--- a/exec/caddytls/caddytls.go
+++ b/exec/caddytls/caddytls.go
@@ -8,6 +8,7 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
+
 	"pkg.para.party/certdx/pkg/domain"
 )
 
@@ -15,7 +16,8 @@ func init() {
 	caddy.RegisterModule(CertDXTls{})
 }
 
-// CertDXTls can get a certificate via HTTP(S) request.
+// CertDXTls is the certmagic.Manager implementation that delegates certificate
+// retrieval to the certdx daemon.
 type CertDXTls struct {
 	ctx       caddy.Context
 	certDXApp *CertDXCaddyDaemon
@@ -23,8 +25,7 @@ type CertDXTls struct {
 	certHash  domain.Key
 }
 
-// CaddyModule returns the Caddy module information.
-func (certdx CertDXTls) CaddyModule() caddy.ModuleInfo {
+func (CertDXTls) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "tls.get_certificate.certdx",
 		New: func() caddy.Module { return new(CertDXTls) },
@@ -39,21 +40,20 @@ func (certdx *CertDXTls) Provision(ctx caddy.Context) error {
 func (certdx *CertDXTls) Validate() error {
 	app, err := certdx.ctx.App("certdx")
 	if err != nil {
-		return fmt.Errorf("failed to get certdx app: %w", err)
+		return fmt.Errorf("certdx app is not configured: %w (add a `certdx { ... }` global options block to your Caddyfile)", err)
 	}
 
-	ok := false
+	var ok bool
 	certdx.certDXApp, ok = app.(*CertDXCaddyDaemon)
 	if !ok {
-		return fmt.Errorf("certdx app has an unexpected type: %T", app)
+		return fmt.Errorf("certdx app has unexpected type %T", app)
 	}
 
-	domains, exists := certdx.certDXApp.CertificateDefs[certdx.CertId]
-	if !exists {
-		return fmt.Errorf("cert definition for cert-id: %v not exists", certdx.CertId)
+	domains, ok := certdx.certDXApp.CertificateDefs.Lookup(certdx.CertId)
+	if !ok {
+		return fmt.Errorf("no certificate definition for cert-id %q", certdx.CertId)
 	}
 	certdx.certHash = domain.AsKey(domains)
-
 	return nil
 }
 
@@ -61,26 +61,24 @@ func (certdx CertDXTls) GetCertificate(ctx context.Context, hello *tls.ClientHel
 	return certdx.certDXApp.GetCertificate(ctx, certdx.certHash)
 }
 
-// UnmarshalCaddyfile deserializes Caddyfile tokens into ts.
+// UnmarshalCaddyfile deserializes Caddyfile tokens.
 //
-//	... certdx [cert-id]
+//	... certdx <cert-id>
 func (certdx *CertDXTls) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		args := d.RemainingArgs()
 		if len(args) != 1 {
-			return d.Errf("expected 1 argument for certdx, got %v", len(args))
+			return d.Errf("expected 1 argument for certdx, got %d", len(args))
 		}
-
 		certdx.CertId = args[0]
 
 		for d.NextBlock(0) {
-			return d.Errf("no block excepted for certdx")
+			return d.Errf("no block expected for certdx")
 		}
 	}
 	return nil
 }
 
-// Interface guards
 var (
 	_ certmagic.Manager     = (*CertDXTls)(nil)
 	_ caddy.Provisioner     = (*CertDXTls)(nil)

--- a/exec/caddytls/certdx.go
+++ b/exec/caddytls/certdx.go
@@ -3,10 +3,13 @@ package caddytls
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+
 	"pkg.para.party/certdx/pkg/client"
 	"pkg.para.party/certdx/pkg/config"
 	"pkg.para.party/certdx/pkg/domain"
@@ -14,12 +17,30 @@ import (
 )
 
 func init() {
-	caddy.RegisterModule(CertDXCaddyDaemon{})
+	caddy.RegisterModule(&CertDXCaddyDaemon{})
 }
 
-// key: cert-id
-// value: domains
+// CertificateDef maps a user-defined cert id to the list of domains it should cover.
 type CertificateDef map[string][]string
+
+func (d CertificateDef) Add(id string, domains []string) error {
+	if id == "" {
+		return fmt.Errorf("certificate id must not be empty")
+	}
+	if len(domains) == 0 {
+		return fmt.Errorf("certificate %q has no domains", id)
+	}
+	if _, ok := d[id]; ok {
+		return fmt.Errorf("certificate %q already defined", id)
+	}
+	d[id] = domains
+	return nil
+}
+
+func (d CertificateDef) Lookup(id string) ([]string, bool) {
+	domains, ok := d[id]
+	return domains, ok
+}
 
 type CertDXCaddyConfig struct {
 	config.ClientCommonConfig
@@ -51,17 +72,17 @@ type CertDXCaddyDaemon struct {
 
 	certDXDaemon *client.CertDXClientDaemon
 	logger       *zap.Logger
+	wg           sync.WaitGroup
 }
 
 func MakeCertDXCaddyDaemon() *CertDXCaddyDaemon {
-	ret := &CertDXCaddyDaemon{}
-	ret.CertificateDefs = make(CertificateDef, 0)
-	ret.SetDefaultConfig()
-
-	return ret
+	d := &CertDXCaddyDaemon{}
+	d.CertificateDefs = make(CertificateDef)
+	d.SetDefaultConfig()
+	return d
 }
 
-func (CertDXCaddyDaemon) CaddyModule() caddy.ModuleInfo {
+func (*CertDXCaddyDaemon) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "certdx",
 		New: func() caddy.Module { return new(CertDXCaddyDaemon) },
@@ -73,49 +94,52 @@ func (m *CertDXCaddyDaemon) Provision(ctx caddy.Context) error {
 	logging.SetLogger(zap.NewStdLog(m.logger))
 
 	m.certDXDaemon = client.MakeCertDXClientDaemon()
-
 	m.certDXDaemon.Config.Common = m.ClientCommonConfig
 	m.certDXDaemon.Config.Http.MainServer = m.Http.MainServer
 	m.certDXDaemon.Config.Http.StandbyServer = m.Http.StandbyServer
 	m.certDXDaemon.Config.GRPC.MainServer = m.GRPC.MainServer
 	m.certDXDaemon.Config.GRPC.StandbyServer = m.GRPC.StandbyServer
 
-	var err error
-	m.certDXDaemon.Config.Common.ReconnectDuration, err = time.ParseDuration(m.ReconnectInterval)
+	d, err := time.ParseDuration(m.ReconnectInterval)
 	if err != nil {
-		m.logger.Fatal("failed to parse interval", zap.Error(err))
-		return err
+		return fmt.Errorf("parse reconnect_interval %q: %w", m.ReconnectInterval, err)
 	}
+	m.certDXDaemon.Config.Common.ReconnectDuration = d
 
 	for certID, domains := range m.CertificateDefs {
 		if err := m.certDXDaemon.AddCertToWatch(certID, domains); err != nil {
-			return err
+			return fmt.Errorf("watch certificate %q: %w", certID, err)
 		}
 	}
-
 	return nil
 }
 
 func (m *CertDXCaddyDaemon) Start() error {
-	switch m.certDXDaemon.Config.Common.Mode {
-	case "http":
+	mode := m.certDXDaemon.Config.Common.Mode
+	switch mode {
+	case config.CLIENT_MODE_HTTP:
 		if m.certDXDaemon.Config.Http.MainServer.Url == "" {
-			m.logger.Fatal("http main server url should not be empty")
+			return fmt.Errorf("http main_server url is required")
 		}
-		go m.certDXDaemon.HttpMain()
-	case "grpc":
+		m.wg.Go(func() {
+			m.certDXDaemon.HttpMain()
+		})
+	case config.CLIENT_MODE_GRPC:
 		if m.certDXDaemon.Config.GRPC.MainServer.Server == "" {
-			m.logger.Fatal("GRPC main server url should not be empty")
+			return fmt.Errorf("grpc main_server is required")
 		}
-		go m.certDXDaemon.GRPCMain()
+		m.wg.Go(func() {
+			m.certDXDaemon.GRPCMain()
+		})
 	default:
-		m.logger.Fatal("not supported mode", zap.String("mode", m.certDXDaemon.Config.Common.Mode))
+		return fmt.Errorf("unsupported mode %q", mode)
 	}
 	return nil
 }
 
 func (m *CertDXCaddyDaemon) Stop() error {
 	m.certDXDaemon.Stop()
+	m.wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
## summary
- port the useful caddytls cleanups from `main-refactor`
- centralize Caddyfile directive names and single-arg parsing
- validate certificate definitions through `CertificateDef.Add/Lookup`
- return startup/provisioning errors instead of `logger.Fatal`
- track the underlying certdx client goroutine and wait on `Stop`

## compatibility
- keeps the existing Caddyfile syntax and cert manager module id unchanged

## verification
- `go build ./...`
- `go vet ./...`
- root `go build ./...`
- root `go vet ./...`
