### PR TITLE
refactor: harden mtls certificate generation

### DIFF
--- a/pkg/tools/cert.go
+++ b/pkg/tools/cert.go
@@ -21,14 +21,19 @@ import (
 	"pkg.para.party/certdx/pkg/paths"
 )
 
-var counter big.Int = *big.NewInt(0)
-
 const (
-	certFileMode = 0o644
-	keyFileMode  = 0o600
-	dataFileMode = 0o644
+	permPrivateKey os.FileMode = 0o600
+	permPublicCert os.FileMode = 0o644
+	permCounter    os.FileMode = 0o644
 )
 
+// counter holds the serial number for the next certificate to be issued.
+// It is persisted to disk in the mTLS directory and incremented after every
+// successful signing.
+var counter big.Int
+
+// MakeCA creates a self-signed CA certificate/key pair at the default mTLS
+// paths. Fails if files already exist to avoid clobbering an in-use CA.
 func MakeCA(organization, commonName string) error {
 	caPEMPath, caKeyPath, err := paths.MtlsCAPath()
 	if err != nil {
@@ -40,26 +45,23 @@ func MakeCA(organization, commonName string) error {
 	}
 
 	if paths.FileExists(caPEMPath) {
-		return fmt.Errorf("CA file: %s already exists", caPEMPath)
+		return fmt.Errorf("CA file already exists: %s", caPEMPath)
 	}
 	if paths.FileExists(caKeyPath) {
-		return fmt.Errorf("CA file: %s already exists", caKeyPath)
+		return fmt.Errorf("CA key already exists: %s", caKeyPath)
 	}
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return err
-	}
-
-	SubjectOrganization := []string{organization}
-	CASubject := pkix.Name{
-		Organization: SubjectOrganization,
-		CommonName:   commonName,
+		return fmt.Errorf("generating CA key: %w", err)
 	}
 
 	ca := &x509.Certificate{
-		SerialNumber:          big.NewInt(0),
-		Subject:               CASubject,
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			Organization: []string{organization},
+			CommonName:   commonName,
+		},
 		NotBefore:             time.Now().Truncate(1 * time.Hour),
 		NotAfter:              time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
 		IsCA:                  true,
@@ -70,38 +72,30 @@ func MakeCA(organization, commonName string) error {
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &priv.PublicKey, priv)
 	if err != nil {
-		return err
+		return fmt.Errorf("self-signing CA: %w", err)
 	}
 
-	caPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: caBytes,
-	})
-	if err := os.WriteFile(caPEMPath, caPEM, certFileMode); err != nil {
+	if err := writePEM(caPEMPath, "CERTIFICATE", caBytes, permPublicCert); err != nil {
 		return err
 	}
-
-	b, err := x509.MarshalPKCS8PrivateKey(priv)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
+		return fmt.Errorf("marshaling CA key: %w", err)
+	}
+	if err := writePEM(caKeyPath, "PRIVATE KEY", keyDER, permPrivateKey); err != nil {
 		return err
 	}
 
-	caKey := pem.EncodeToMemory(&pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: b,
-	})
-	if err := os.WriteFile(caKeyPath, caKey, keyFileMode); err != nil {
-		return err
+	if err := os.WriteFile(caCounterPath, []byte(counter.String()), permCounter); err != nil {
+		return fmt.Errorf("writing serial counter: %w", err)
 	}
 
-	if err := os.WriteFile(caCounterPath, []byte(counter.String()), dataFileMode); err != nil {
-		return err
-	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes})
 	fmt.Println(string(caPEM))
 	return nil
 }
 
-func loadCA() (*x509.Certificate, *crypto.PrivateKey, error) {
+func loadCA() (*x509.Certificate, crypto.PrivateKey, error) {
 	caPEMPath, caKeyPath, err := paths.MtlsCAPath()
 	if err != nil {
 		return nil, nil, err
@@ -113,31 +107,30 @@ func loadCA() (*x509.Certificate, *crypto.PrivateKey, error) {
 
 	caPEMData, err := os.ReadFile(caPEMPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("reading CA cert: %w", err)
 	}
 	caKeyData, err := os.ReadFile(caKeyPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("reading CA key: %w", err)
 	}
 	caCounterData, err := os.ReadFile(caCounterPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("reading serial counter: %w", err)
 	}
 
 	caPEM, err := certcrypto.ParsePEMCertificate(caPEMData)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("parsing CA cert: %w", err)
 	}
 	caKey, err := certcrypto.ParsePEMPrivateKey(caKeyData)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("parsing CA key: %w", err)
 	}
-	_, ok := counter.SetString(string(caCounterData), 10)
-	if !ok {
-		return nil, nil, fmt.Errorf("bad counter")
+	if _, ok := counter.SetString(string(caCounterData), 10); !ok {
+		return nil, nil, fmt.Errorf("invalid serial number counter in %s", caCounterPath)
 	}
 
-	return caPEM, &caKey, nil
+	return caPEM, caKey, nil
 }
 
 func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
@@ -152,110 +145,118 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 	if _, err = asn1.Unmarshal(b, &info); err != nil {
 		return nil, err
 	}
-	hash := sha1.Sum(info.SubjectPublicKey.Bytes)
-	return hash[:], nil
+	sum := sha1.Sum(info.SubjectPublicKey.Bytes)
+	return sum[:], nil
 }
 
-func makeCert(PEMPath, keyPath, organization, commonName string,
-	domains []string, extKeyUseage []x509.ExtKeyUsage) error {
+// splitIPsAndDNS separates literal IP addresses out of a mixed list of
+// DNS names and addresses. Literal IPs remain in the SANs as IPAddresses
+// rather than DNSNames, as required by RFC 5280.
+func splitIPsAndDNS(names []string) (dns []string, ips []net.IP) {
+	for _, n := range names {
+		if ip := net.ParseIP(n); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			dns = append(dns, n)
+		}
+	}
+	return
+}
+
+func makeCert(pemPath, keyPath, organization, commonName string,
+	domains []string, extKeyUsage []x509.ExtKeyUsage) error {
 
 	counterPath, err := paths.CACounterPath()
 	if err != nil {
 		return err
 	}
 
-	if paths.FileExists(PEMPath) {
-		return fmt.Errorf("file: %s already exists", PEMPath)
+	if paths.FileExists(pemPath) {
+		return fmt.Errorf("cert file already exists: %s", pemPath)
 	}
 	if paths.FileExists(keyPath) {
-		return fmt.Errorf("file: %s already exists", keyPath)
+		return fmt.Errorf("key file already exists: %s", keyPath)
 	}
 
-	caPEM, pcaKey, err := loadCA()
+	caCert, caKey, err := loadCA()
 	if err != nil {
-		return fmt.Errorf("failed to load CA: %w", err)
-	}
-	caKey := *pcaKey
-
-	ipAddresses := []net.IP{}
-	for _, domain := range domains {
-		addr := net.ParseIP(domain)
-		if addr != nil {
-			ipAddresses = append(ipAddresses, addr)
-		}
+		return fmt.Errorf("loading CA: %w", err)
 	}
 
-	SubjectOrganization := []string{organization}
-	Subject := pkix.Name{
-		Organization: SubjectOrganization,
-		CommonName:   commonName,
+	dnsNames, ipAddresses := splitIPsAndDNS(domains)
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generating key: %w", err)
+	}
+
+	skid, err := generateSubjectKeyID(priv.Public())
+	if err != nil {
+		return fmt.Errorf("computing SKI: %w", err)
 	}
 
 	cert := &x509.Certificate{
 		SerialNumber: &counter,
-		Subject:      Subject,
-		DNSNames:     domains,
+		Subject: pkix.Name{
+			Organization: []string{organization},
+			CommonName:   commonName,
+		},
+		DNSNames:     dnsNames,
 		IPAddresses:  ipAddresses,
 		NotBefore:    time.Now().Truncate(1 * time.Hour),
 		NotAfter:     time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
-		ExtKeyUsage:  extKeyUseage,
+		ExtKeyUsage:  extKeyUsage,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
+		SubjectKeyId: skid,
 	}
 
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &priv.PublicKey, caKey)
 	if err != nil {
-		return err
+		return fmt.Errorf("signing certificate: %w", err)
 	}
 
-	cert.SubjectKeyId, err = generateSubjectKeyID(priv.Public())
+	if err := writePEM(pemPath, "CERTIFICATE", certBytes, permPublicCert); err != nil {
+		return err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshaling private key: %w", err)
 	}
-
-	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caPEM, &priv.PublicKey, caKey)
-	if err != nil {
-		return err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certBytes,
-	})
-	if err := os.WriteFile(PEMPath, certPEM, certFileMode); err != nil {
-		return err
-	}
-
-	b, err := x509.MarshalPKCS8PrivateKey(priv)
-	if err != nil {
-		return err
-	}
-
-	certKey := pem.EncodeToMemory(&pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: b,
-	})
-	if err := os.WriteFile(keyPath, certKey, keyFileMode); err != nil {
+	if err := writePEM(keyPath, "PRIVATE KEY", keyDER, permPrivateKey); err != nil {
 		return err
 	}
 
 	counter.Add(&counter, big.NewInt(1))
-	if err := os.WriteFile(counterPath, []byte(counter.String()), dataFileMode); err != nil {
-		return err
+	if err := os.WriteFile(counterPath, []byte(counter.String()), permCounter); err != nil {
+		return fmt.Errorf("writing serial counter: %w", err)
 	}
 
-	fmt.Println(string(certPEM))
-	fmt.Println(string(certKey))
+	fmt.Println(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})))
+	fmt.Println(string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})))
 	return nil
 }
 
+// writePEM PEM-encodes der under typ and installs it at path with the given
+// permissions.
+func writePEM(path, typ string, der []byte, mode os.FileMode) error {
+	encoded := pem.EncodeToMemory(&pem.Block{Type: typ, Bytes: der})
+	if err := os.WriteFile(path, encoded, mode); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// MakeServerCert issues a server certificate signed by the local CA.
 func MakeServerCert(organization, commonName string, domains []string) error {
-	servPEMPath, servKeyPath, err := paths.MtlsServerCertPath()
+	pemPath, keyPath, err := paths.MtlsServerCertPath()
 	if err != nil {
 		return err
 	}
-	return makeCert(servPEMPath, servKeyPath, organization, commonName, domains, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+	return makeCert(pemPath, keyPath, organization, commonName, domains,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
 }
 
+// MakeClientCert issues a named client certificate signed by the local CA.
 func MakeClientCert(name, organization, commonName string, domains []string) error {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "ca", "server":
@@ -266,5 +267,6 @@ func MakeClientCert(name, organization, commonName string, domains []string) err
 	if err != nil {
 		return err
 	}
-	return makeCert(clientPEMPath, clientKeyPath, organization, commonName, domains, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	return makeCert(clientPEMPath, clientKeyPath, organization, commonName, domains,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
 }

--- a/pkg/tools/cert_test.go
+++ b/pkg/tools/cert_test.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"net"
+	"testing"
+)
+
+func TestSplitIPsAndDNS(t *testing.T) {
+	dns, ips := splitIPsAndDNS([]string{
+		"example.com",
+		"127.0.0.1",
+		"api.example.com",
+		"::1",
+	})
+
+	if got, want := len(dns), 2; got != want {
+		t.Fatalf("dns count = %d, want %d: %v", got, want, dns)
+	}
+	if dns[0] != "example.com" || dns[1] != "api.example.com" {
+		t.Fatalf("unexpected dns names: %v", dns)
+	}
+
+	wantIPs := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+	if got, want := len(ips), len(wantIPs); got != want {
+		t.Fatalf("ip count = %d, want %d: %v", got, want, ips)
+	}
+	for i := range wantIPs {
+		if !ips[i].Equal(wantIPs[i]) {
+			t.Fatalf("ip[%d] = %v, want %v", i, ips[i], wantIPs[i])
+		}
+	}
+}


### PR DESCRIPTION
## summary
- port `pkg/tools/cert.go` cleanups from `main-refactor`
- wrap cert/key/counter read/write/signing errors with context
- centralize PEM writing with explicit file modes
- split literal IP SANs out of DNS SANs before signing certificates
- keep the existing reserved mTLS client-name guard from main
- add a focused unit test for IP/DNS SAN splitting

## bugfix note
- fixes IP literals being written to both `DNSNames` and `IPAddresses`; after this change, IP literals only go into `IPAddresses` as required by x509 SAN semantics

## verification
- `go test ./pkg/tools`
- `git diff --check`
- `go build ./...`
- `go vet ./...`
- `go build ./...` in `exec/tools`
- `go vet ./...` in `exec/tools`
- `go test -tags=e2e -count=1 -timeout=10m -v ./...` in `test/e2e`
