### PR TITLE
fix: make server subscription lifecycle atomic

### DIFF
--- a/pkg/server/cert_entry.go
+++ b/pkg/server/cert_entry.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"pkg.para.party/certdx/pkg/domain"
 )
@@ -19,9 +18,9 @@ import (
 //     pair, the `updated` chan swap, and the cancelRenew handle that
 //     subscribe / release shuffle. It is held only briefly, so readers
 //     (Snapshot, WaitForUpdate) never block waiting on an ACME call to finish.
-//   - subscribing is the consumer refcount. subscribe transitions 0->1 spawn
-//     the renewal goroutine; release transitions 1->0 cancel it via
-//     cancelRenew.
+//   - subscribing is the consumer refcount, guarded by stateMu. subscribe
+//     transitions 0->1 spawn the renewal goroutine; release transitions 1->0
+//     cancel it via cancelRenew.
 type certEntry struct {
 	domains []string
 
@@ -33,7 +32,7 @@ type certEntry struct {
 	updated     chan struct{} // closed on each successful renewal, then replaced
 	cancelRenew context.CancelFunc
 
-	subscribing atomic.Int64
+	subscribing int64
 }
 
 type certCache struct {

--- a/pkg/server/cert_entry_test.go
+++ b/pkg/server/cert_entry_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func makeValidTestEntry() *certEntry {
+	entry := newCertEntry([]string{"example.com"})
+	entry.cert = CertT{ValidBefore: time.Now().Add(time.Hour)}
+	return entry
+}
+
+func TestSubscribeReleaseClearsRenewer(t *testing.T) {
+	s := MakeCertDXServer()
+	entry := makeValidTestEntry()
+
+	s.subscribe(entry)
+
+	entry.stateMu.Lock()
+	if entry.subscribing != 1 {
+		t.Fatalf("subscribing = %d, want 1", entry.subscribing)
+	}
+	if entry.cancelRenew == nil {
+		t.Fatal("cancelRenew is nil after first subscribe")
+	}
+	entry.stateMu.Unlock()
+
+	s.release(entry)
+
+	entry.stateMu.Lock()
+	defer entry.stateMu.Unlock()
+	if entry.subscribing != 0 {
+		t.Fatalf("subscribing = %d, want 0", entry.subscribing)
+	}
+	if entry.cancelRenew != nil {
+		t.Fatal("cancelRenew was not cleared after last release")
+	}
+}
+
+func TestSubscribeReleaseConcurrentBalanced(t *testing.T) {
+	s := MakeCertDXServer()
+	entry := makeValidTestEntry()
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.subscribe(entry)
+			s.release(entry)
+		}()
+	}
+	wg.Wait()
+
+	entry.stateMu.Lock()
+	defer entry.stateMu.Unlock()
+	if entry.subscribing != 0 {
+		t.Fatalf("subscribing = %d, want 0", entry.subscribing)
+	}
+	if entry.cancelRenew != nil {
+		t.Fatal("cancelRenew was not cleared after balanced releases")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -202,11 +202,22 @@ func (s *CertDXServer) subscribeCertCacheEntry(ctx context.Context, c *certEntry
 // derived from rootCtx (so server Stop drains it cleanly); further
 // subscribers just bump the refcount.
 func (s *CertDXServer) subscribe(c *certEntry) {
-	if c.subscribing.Add(1) == 1 {
-		ctx, cancel := context.WithCancel(s.rootCtx)
-		c.stateMu.Lock()
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		start  bool
+	)
+
+	c.stateMu.Lock()
+	if c.subscribing == 0 {
+		ctx, cancel = context.WithCancel(s.rootCtx)
 		c.cancelRenew = cancel
-		c.stateMu.Unlock()
+		start = true
+	}
+	c.subscribing++
+	c.stateMu.Unlock()
+
+	if start {
 		go s.subscribeCertCacheEntry(ctx, c)
 	}
 }
@@ -214,19 +225,29 @@ func (s *CertDXServer) subscribe(c *certEntry) {
 // Release drops a consumer. When the last consumer leaves, the renewal
 // goroutine's context is cancelled and it winds down.
 func (s *CertDXServer) release(c *certEntry) {
-	if c.subscribing.Add(-1) == 0 {
-		c.stateMu.Lock()
-		cancel := c.cancelRenew
+	var cancel context.CancelFunc
+
+	c.stateMu.Lock()
+	if c.subscribing > 0 {
+		c.subscribing--
+	}
+	if c.subscribing == 0 {
+		cancel = c.cancelRenew
 		c.cancelRenew = nil
 		c.stateMu.Unlock()
-		if cancel != nil {
-			cancel()
-		}
+	} else {
+		c.stateMu.Unlock()
+	}
+
+	if cancel != nil {
+		cancel()
 	}
 }
 
 func (s *CertDXServer) isSubscribing(c *certEntry) bool {
-	return c.subscribing.Load() != 0
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.subscribing != 0
 }
 
 // Stop signals every server goroutine to wind down. It is safe to call


### PR DESCRIPTION
## Summary
- guard `subscribing` and `cancelRenew` under `stateMu`
- ensure the 0→1 transition stores the renewal cancel func before any release can observe the subscriber count
- add server tests for cleanup and balanced concurrent subscribe/release

Closes #13

## Verification
- `go test -race ./pkg/server`
- `go build ./...`
- `go vet ./...`
- `git diff --check`
