### PR TITLE
fix: ACME account key + S3 provider crash paths (audit PR 3)

### DIFF
--- a/pkg/acme/challengeproviders/s3/s3.go
+++ b/pkg/acme/challengeproviders/s3/s3.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,31 +26,36 @@ func (s *HTTPProvider) Client() *s3.Client {
 }
 
 // NewHTTPProvider returns a HTTPProvider instance with a configured s3 bucket and aws session.
-// Credentials must be passed in the environment variables.
-func NewHTTPProvider(config config.S3Client) (*HTTPProvider, error) {
-	credential := credentials.NewStaticCredentialsProvider(config.AccessKeyId, config.AccessKeySecret, config.SessionToken)
+// Credentials must be passed in the environment variables. The bucket name
+// is required; an empty bucket fails fast rather than producing opaque
+// runtime errors deep inside an ACME challenge.
+func NewHTTPProvider(cfg config.S3Client) (*HTTPProvider, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("s3 challenge provider: bucket is required")
+	}
+
+	credential := credentials.NewStaticCredentialsProvider(cfg.AccessKeyId, cfg.AccessKeySecret, cfg.SessionToken)
 	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 		return aws.Endpoint{
-			PartitionID:   config.PartitionID,
-			URL:           config.URL,
-			SigningRegion: config.Region,
+			PartitionID:   cfg.PartitionID,
+			URL:           cfg.URL,
+			SigningRegion: cfg.Region,
 		}, nil
 	})
 
-	cfg, err := awsConfig.LoadDefaultConfig(
-		context.TODO(),
+	awsCfg, err := awsConfig.LoadDefaultConfig(
+		context.Background(),
 		awsConfig.WithCredentialsProvider(credential),
 		awsConfig.WithEndpointResolverWithOptions(customResolver),
 		awsConfig.WithRegion("auto"),
 	)
 	if err != nil {
-		log.Printf("LoadDefaultConfig error: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("load AWS config: %w", err)
 	}
 
 	return &HTTPProvider{
-		bucket: config.Bucket,
-		client: s3.NewFromConfig(cfg, func(o *s3.Options) {
+		bucket: cfg.Bucket,
+		client: s3.NewFromConfig(awsCfg, func(o *s3.Options) {
 			o.UsePathStyle = false
 		}),
 	}, nil

--- a/pkg/acme/challengeproviders/s3/s3_test.go
+++ b/pkg/acme/challengeproviders/s3/s3_test.go
@@ -12,13 +12,24 @@ import (
 	"pkg.para.party/certdx/pkg/config"
 )
 
+// TestS3 exercises the S3 challenge provider against a live bucket. It is
+// skipped unless ACCESSKEYID, ACCESSKEYSECRET, and BUCKET are all set so
+// `go test ./...` does not fail on a developer machine without S3
+// credentials.
 func TestS3(t *testing.T) {
+	bucket := os.Getenv("BUCKET")
+	accessKey := os.Getenv("ACCESSKEYID")
+	accessSecret := os.Getenv("ACCESSKEYSECRET")
+	if bucket == "" || accessKey == "" || accessSecret == "" {
+		t.Skip("skipping live S3 test: ACCESSKEYID, ACCESSKEYSECRET, BUCKET must all be set")
+	}
+
 	provider, err := s3.NewHTTPProvider(config.S3Client{
 		Region:          "ap-beijing",
 		PartitionID:     "aws",
-		AccessKeyId:     os.Getenv("ACCESSKEYID"),
-		AccessKeySecret: os.Getenv("ACCESSKEYSECRET"),
-		Bucket:          os.Getenv("BUCKET"),
+		AccessKeyId:     accessKey,
+		AccessKeySecret: accessSecret,
+		Bucket:          bucket,
 		URL:             "https://cos.ap-beijing.myqcloud.com",
 	})
 	if err != nil {
@@ -26,7 +37,7 @@ func TestS3(t *testing.T) {
 	}
 
 	out, err := provider.Client().PutObject(context.Background(), &awsS3.PutObjectInput{
-		Bucket:       aws.String(os.Getenv("BUCKET")),
+		Bucket:       aws.String(bucket),
 		Key:          aws.String("test"),
 		Body:         strings.NewReader("xxxxxxx"),
 		StorageClass: "STANDARD",

--- a/pkg/acme/user.go
+++ b/pkg/acme/user.go
@@ -36,12 +36,13 @@ func (u *ACMEUser) GetPrivateKey() crypto.PrivateKey {
 	return u.Key
 }
 
+// parsePEM decodes a PEM-encoded ACME account key. A corrupted file is
+// returned as an error rather than crashing the process.
 func parsePEM(pem []byte) (crypto.PrivateKey, error) {
 	key, err := certcrypto.ParsePEMPrivateKey(pem)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("parse ACME account key: %w", err)
 	}
-
 	return key, nil
 }
 
@@ -95,7 +96,7 @@ func makeACMEUser(c *config.ServerConfig) (*ACMEUser, error) {
 
 	user.Registration, err = acmeClient.Registration.ResolveAccountByKey()
 	if err != nil {
-		return nil, fmt.Errorf("failed resolving account. Is account registered? Error: %w", err)
+		return nil, fmt.Errorf("resolve ACME account by key (is the account registered?): %w", err)
 	}
 	return user, nil
 }
@@ -111,12 +112,14 @@ func RegisterAccount(ACMEProvider, Email, Kid, Hmac string) error {
 		return fmt.Errorf("failed generating key: %w", err)
 	}
 
-	x509Encoded, _ := x509.MarshalECPrivateKey(privateKey)
+	x509Encoded, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return fmt.Errorf("marshal ACME account key: %w", err)
+	}
 	pemEncoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509Encoded})
 
-	err = os.WriteFile(keyPath, pemEncoded, 0o600)
-	if err != nil {
-		return fmt.Errorf("failed saving key: %w", err)
+	if err := os.WriteFile(keyPath, pemEncoded, 0o600); err != nil {
+		return fmt.Errorf("save ACME account key: %w", err)
 	}
 
 	myUser := ACMEUser{


### PR DESCRIPTION
## Summary

Audit PR 3, closes task #15. Three independent crash-path fixes in `pkg/acme` and one in `pkg/acme/challengeproviders/s3`.

## What landed

**`pkg/acme/user.go`**

1. **`parsePEM` no longer panics** on a corrupt ACME account key file. Returns the underlying lego/certcrypto parse error wrapped with context. A bad on-disk key now fails server startup gracefully instead of crashing the whole process.
2. **`RegisterAccount` no longer discards the `x509.MarshalECPrivateKey` return value.** Marshal failures are propagated; the caller can clean up the half-written key path.
3. **`makeACMEUser`'s "failed resolving account" message** had embedded sentence punctuation (`"failed resolving account. Is account registered? Error:"`). Flattened to one phrase so log lines and error chains stay grep-able.

**`pkg/acme/challengeproviders/s3/`**

4. **`NewHTTPProvider` rejects an empty bucket up front** instead of surfacing as an opaque AWS SDK error in the middle of a challenge.
5. Drops the stray `log.Printf` import + call; errors propagate via the return value.
6. **`s3_test.go` no longer panics** under `go test ./...` when `ACCESSKEYID` / `ACCESSKEYSECRET` / `BUCKET` are unset; it skips with a clear message. This unblocks running the full unit-test suite locally.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/acme/...` — s3 test now skips cleanly on a dev box
- `go test -race -tags=e2e -count=1 -timeout=10m ./...` under `test/e2e/` ✅ (~260s)

## Refs

- Closes task #15
- Part of the task-#11 audit cleanup (companion PRs in flight: #54 lifecycle race by @Alisaie, more to follow)

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] `go test ./pkg/acme/...` succeeds; s3 test skips without env vars
- [x] Full e2e suite passes locally with `-race`
- [x] CI green on PR
