### PR TITLE
fix: return server lifecycle errors

### DIFF
--- a/exec/server/main.go
+++ b/exec/server/main.go
@@ -79,7 +79,6 @@ func main() {
 				case errChan <- fmt.Errorf("%s server: %w", name, err):
 				default:
 				}
-				cdxsrv.Stop()
 			}
 		}()
 	}
@@ -92,17 +91,10 @@ func main() {
 		startServer("grpc sds", cdxsrv.SDSSrv)
 	}
 
-	shutdownDone := make(chan struct{})
-	go func() {
-		cli.WaitForShutdown(cdxsrv.Stop, shutdownTimeout)
-		close(shutdownDone)
-	}()
-
-	select {
-	case err := <-errChan:
+	if err := cli.WaitForShutdown(func() {
+		cdxsrv.Stop()
 		wg.Wait()
+	}, shutdownTimeout, errChan); err != nil {
 		logging.Fatal("%s", err)
-	case <-shutdownDone:
-		wg.Wait()
 	}
 }

--- a/exec/server/main.go
+++ b/exec/server/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -65,13 +67,42 @@ func init() {
 }
 
 func main() {
+	errChan := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	startServer := func(name string, run func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := run(); err != nil {
+				select {
+				case errChan <- fmt.Errorf("%s server: %w", name, err):
+				default:
+				}
+				cdxsrv.Stop()
+			}
+		}()
+	}
+
 	if cdxsrv.Config.HttpServer.Enabled {
-		go cdxsrv.HttpSrv()
+		startServer("http", cdxsrv.HttpSrv)
 	}
 
 	if cdxsrv.Config.GRPCSDSServer.Enabled {
-		go cdxsrv.SDSSrv()
+		startServer("grpc sds", cdxsrv.SDSSrv)
 	}
 
-	cli.WaitForShutdown(cdxsrv.Stop, shutdownTimeout)
+	shutdownDone := make(chan struct{})
+	go func() {
+		cli.WaitForShutdown(cdxsrv.Stop, shutdownTimeout)
+		close(shutdownDone)
+	}()
+
+	select {
+	case err := <-errChan:
+		wg.Wait()
+		logging.Fatal("%s", err)
+	case <-shutdownDone:
+		wg.Wait()
+	}
 }

--- a/pkg/cli/signal.go
+++ b/pkg/cli/signal.go
@@ -9,19 +9,29 @@ import (
 	"pkg.para.party/certdx/pkg/logging"
 )
 
-// WaitForShutdown blocks until SIGINT or SIGTERM arrives, then invokes
-// stop in a goroutine and waits up to forceTimeout for it to return.
+// WaitForShutdown blocks until SIGINT/SIGTERM arrives or errCh reports
+// a background service failure. It then invokes stop in a goroutine
+// and waits up to forceTimeout for it to return.
 //
 //   - A second signal during graceful shutdown escalates to a hard exit
 //     via logging.Fatal.
 //   - If stop does not return within forceTimeout, the process is also
 //     forced to exit.
-func WaitForShutdown(stop func(), forceTimeout time.Duration) {
+func WaitForShutdown(stop func(), forceTimeout time.Duration, errCh ...<-chan error) error {
 	sig := make(chan os.Signal, 2)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sig)
 
-	<-sig
+	var serviceErr error
+	var errs <-chan error
+	if len(errCh) > 0 {
+		errs = errCh[0]
+	}
+
+	select {
+	case <-sig:
+	case serviceErr = <-errs:
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -31,10 +41,11 @@ func WaitForShutdown(stop func(), forceTimeout time.Duration) {
 
 	select {
 	case <-done:
-		return
+		return serviceErr
 	case <-sig:
 		logging.Fatal("Forced shutdown")
 	case <-time.After(forceTimeout):
 		logging.Fatal("Graceful shutdown timed out after %s", forceTimeout)
 	}
+	return serviceErr
 }

--- a/pkg/server/cert_store.go
+++ b/pkg/server/cert_store.go
@@ -78,17 +78,29 @@ func (s *CertStore) PrintCertInfo() {
 }
 
 // listenUpdate drains the cert-store update queue, persisting each renewed cert
-// to disk. It exits when ctx is done so it shares the server's lifecycle.
+// to disk. When ctx is done, it flushes queued updates before exiting so a
+// renewal that completed just before shutdown is not dropped.
 func (s *CertStore) listenUpdate(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case fe := <-s.update:
-			logging.Info("Update domains cache to file")
-			if err := s.saveEntry(fe); err != nil {
-				logging.Warn("Update domains cache to file failed, err: %s", err)
+			for {
+				select {
+				case fe := <-s.update:
+					s.logSaveEntry(fe)
+				default:
+					return
+				}
 			}
+		case fe := <-s.update:
+			s.logSaveEntry(fe)
 		}
+	}
+}
+
+func (s *CertStore) logSaveEntry(fe *certStoreEntry) {
+	logging.Info("Update domains cache to file")
+	if err := s.saveEntry(fe); err != nil {
+		logging.Warn("Update domains cache to file failed, err: %s", err)
 	}
 }

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -1,18 +1,23 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"pkg.para.party/certdx/pkg/api"
 	"pkg.para.party/certdx/pkg/config"
 	"pkg.para.party/certdx/pkg/domain"
 	"pkg.para.party/certdx/pkg/logging"
 )
+
+const httpShutdownTimeout = 30 * time.Second
 
 func (s *CertDXServer) apiHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == s.Config.HttpServer.APIPath {
@@ -107,7 +112,16 @@ ERR:
 	http.Error(*w, "", http.StatusInternalServerError)
 }
 
-func (s *CertDXServer) serveHttps() {
+func shutdownHTTPServer(server *http.Server) error {
+	ctx, cancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func (s *CertDXServer) serveHttps(handler http.Handler) error {
 	ctx := s.rootCtx
 	entry := s.certCache.get(s.Config.HttpServer.Names)
 
@@ -118,7 +132,7 @@ func (s *CertDXServer) serveHttps() {
 	if !cert.IsValid() {
 		seen = entry.WaitForUpdate(ctx, seen)
 		if ctx.Err() != nil {
-			return
+			return nil
 		}
 		cert, seen = entry.Snapshot()
 	}
@@ -126,77 +140,148 @@ func (s *CertDXServer) serveHttps() {
 	for {
 		certificate, err := tls.X509KeyPair(cert.FullChain, cert.Key)
 		if err != nil {
-			logging.Fatal("Failed to load cert, err: %s", err)
+			return fmt.Errorf("load HTTPS certificate: %w", err)
 		}
 
 		server := http.Server{
-			Addr: s.Config.HttpServer.Listen,
+			Addr:    s.Config.HttpServer.Listen,
+			Handler: handler,
+			TLSConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				Certificates: []tls.Certificate{certificate},
+			},
 		}
 
-		server.TLSConfig = &tls.Config{
-			MinVersion:   tls.VersionTLS12,
-			Certificates: []tls.Certificate{certificate},
-		}
-
+		errChan := make(chan error, 1)
 		go func() {
 			logging.Info("Https server started")
 			err := server.ListenAndServeTLS("", "")
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errChan <- err
+				return
+			}
 			logging.Info("Https server stopped: %s", err)
+			errChan <- nil
 		}()
 
-		seen = entry.WaitForUpdate(ctx, seen)
-		server.Close()
-		if ctx.Err() != nil {
-			return
+		waitCtx, cancelWait := context.WithCancel(ctx)
+		update := make(chan uint64, 1)
+		go func() {
+			update <- entry.WaitForUpdate(waitCtx, seen)
+		}()
+
+		select {
+		case err := <-errChan:
+			cancelWait()
+			if err != nil {
+				return fmt.Errorf("serve HTTPS: %w", err)
+			}
+			return nil
+		case seen = <-update:
+			cancelWait()
+			if err := shutdownHTTPServer(&server); err != nil {
+				return fmt.Errorf("shutdown HTTPS server: %w", err)
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			cert, seen = entry.Snapshot()
+			continue
+		case <-ctx.Done():
+			cancelWait()
+			if err := shutdownHTTPServer(&server); err != nil {
+				return fmt.Errorf("shutdown HTTPS server: %w", err)
+			}
+			return nil
 		}
-		cert, seen = entry.Snapshot()
 	}
 }
 
-func (s *CertDXServer) serveHttp() {
+func (s *CertDXServer) serveHttp(handler http.Handler) error {
 	server := http.Server{
-		Addr: s.Config.HttpServer.Listen,
+		Addr:    s.Config.HttpServer.Listen,
+		Handler: handler,
 	}
 
+	errChan := make(chan error, 1)
 	go func() {
 		logging.Info("Http server started")
 		err := server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errChan <- err
+			return
+		}
 		logging.Info("Http server stopped: %s", err)
+		errChan <- nil
 	}()
 
-	<-s.rootCtx.Done()
-	server.Close()
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return fmt.Errorf("serve HTTP: %w", err)
+		}
+		return nil
+	case <-s.rootCtx.Done():
+		if err := shutdownHTTPServer(&server); err != nil {
+			return fmt.Errorf("shutdown HTTP server: %w", err)
+		}
+		return nil
+	}
 }
 
-func (s *CertDXServer) serveHttpMtls() {
-	server := http.Server{
-		Addr:      s.Config.HttpServer.Listen,
-		TLSConfig: getMtlsConfig(),
+func (s *CertDXServer) serveHttpMtls(handler http.Handler) error {
+	mtlsConfig, err := getMtlsConfig()
+	if err != nil {
+		return err
 	}
 
+	server := http.Server{
+		Addr:      s.Config.HttpServer.Listen,
+		Handler:   handler,
+		TLSConfig: mtlsConfig,
+	}
+
+	errChan := make(chan error, 1)
 	go func() {
 		logging.Info("Http mtls server started")
 		err := server.ListenAndServeTLS("", "")
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errChan <- err
+			return
+		}
 		logging.Info("Http mtls server stopped: %s", err)
+		errChan <- nil
 	}()
 
-	<-s.rootCtx.Done()
-	server.Close()
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return fmt.Errorf("serve HTTP mTLS: %w", err)
+		}
+		return nil
+	case <-s.rootCtx.Done():
+		if err := shutdownHTTPServer(&server); err != nil {
+			return fmt.Errorf("shutdown HTTP mTLS server: %w", err)
+		}
+		return nil
+	}
 }
 
 // HttpSrv runs the HTTP API endpoint until Stop is called.
-func (s *CertDXServer) HttpSrv() {
+func (s *CertDXServer) HttpSrv() error {
 	logging.Info("Start listening Http at %s%s", s.Config.HttpServer.Listen, s.Config.HttpServer.APIPath)
 
+	mux := http.NewServeMux()
 	if s.Config.HttpServer.AuthMethod == config.HTTP_AUTH_TOKEN {
-		http.HandleFunc("/", s.apiWithTokenHandler)
+		mux.HandleFunc("/", s.apiWithTokenHandler)
 		if !s.Config.HttpServer.Secure {
-			s.serveHttp()
+			return s.serveHttp(mux)
 		} else {
-			s.serveHttps()
+			return s.serveHttps(mux)
 		}
 	} else if s.Config.HttpServer.AuthMethod == config.HTTP_AUTH_MTLS {
-		http.HandleFunc("/", s.apiHandler)
-		s.serveHttpMtls()
+		mux.HandleFunc("/", s.apiHandler)
+		return s.serveHttpMtls(mux)
 	}
+	return fmt.Errorf("unsupported HTTP auth method: %s", s.Config.HttpServer.AuthMethod)
 }

--- a/pkg/server/mtls.go
+++ b/pkg/server/mtls.go
@@ -3,35 +3,35 @@ package server
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 
-	"pkg.para.party/certdx/pkg/logging"
 	"pkg.para.party/certdx/pkg/paths"
 )
 
-func getMtlsConfig() *tls.Config {
+func getMtlsConfig() (*tls.Config, error) {
 	srvCertPath, srvKeyPath, err := paths.MtlsServerCertPath()
 	if err != nil {
-		logging.Fatal("err: %s", err)
+		return nil, fmt.Errorf("resolve mtls server certificate path: %w", err)
 	}
 
 	cert, err := tls.LoadX509KeyPair(srvCertPath, srvKeyPath)
 	if err != nil {
-		logging.Fatal("Invalid server cert, err: %s", err)
+		return nil, fmt.Errorf("load mtls server certificate: %w", err)
 	}
 
 	caPEMPath, _, err := paths.MtlsCAPath()
 	if err != nil {
-		logging.Fatal("%s", err)
+		return nil, fmt.Errorf("resolve mtls ca path: %w", err)
 	}
 	caPEM, err := os.ReadFile(caPEMPath)
 	if err != nil {
-		logging.Fatal("err: %s", err)
+		return nil, fmt.Errorf("read mtls ca certificate: %w", err)
 	}
 
 	capool := x509.NewCertPool()
 	if !capool.AppendCertsFromPEM(caPEM) {
-		logging.Fatal("Invalid ca cert")
+		return nil, fmt.Errorf("parse mtls ca certificate")
 	}
 
 	return &tls.Config{
@@ -40,5 +40,5 @@ func getMtlsConfig() *tls.Config {
 		ClientCAs:    capool,
 		MinVersion:   tls.VersionTLS13,
 		MaxVersion:   tls.VersionTLS13,
-	}
+	}, nil
 }

--- a/pkg/server/sds.go
+++ b/pkg/server/sds.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -31,14 +32,23 @@ type MySDS struct {
 func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSecretsServer) error {
 	ctx := server.Context()
 	peerInfo, _ := peer.FromContext(ctx)
-	peer := peerInfo.Addr.String()
+	peer := "unknown"
+	if peerInfo != nil && peerInfo.Addr != nil {
+		peer = peerInfo.Addr.String()
+	}
 
 	logging.Info("New gRPC connection from: %s", peer)
 
 	dispatch := map[string]chan *discoveryv3.DiscoveryRequest{}
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 
 	resp := make(chan *discoveryv3.DiscoveryResponse)
+	sendErr := func(err error) {
+		select {
+		case errChan <- err:
+		case <-ctx.Done():
+		}
+	}
 	go func() {
 		// goroutine for sending
 		for {
@@ -46,7 +56,7 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 			case r := <-resp:
 				if err := server.Send(r); err != nil {
 					// a failed in sending should make the context fail as well.
-					errChan <- fmt.Errorf("failed sending message: %w", err)
+					sendErr(fmt.Errorf("failed sending message: %w", err))
 					return
 				}
 			case <-ctx.Done():
@@ -70,24 +80,29 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 
 			req, err := server.Recv()
 			if err != nil {
-				errChan <- fmt.Errorf("failed receiving request from %s: %w", peer, err)
+				sendErr(fmt.Errorf("failed receiving request from %s: %w", peer, err))
 				return
 			}
 
 			if req.TypeUrl != typeUrl {
-				errChan <- fmt.Errorf("unexpected resource type: expect `%s` but requested `%s`", typeUrl, req.TypeUrl)
+				sendErr(fmt.Errorf("unexpected resource type: expect `%s` but requested `%s`", typeUrl, req.TypeUrl))
+				return
 			}
 
 			if domainSets == nil {
+				if req.Node == nil || req.Node.Metadata == nil {
+					sendErr(fmt.Errorf("bad metadata, no node metadata"))
+					return
+				}
 				if _domainSets, exist := req.Node.Metadata.Fields[domainKey]; exist {
 					if _domainSets, ok := _domainSets.AsInterface().(map[string]interface{}); ok {
 						domainSets = _domainSets
 					} else {
-						errChan <- fmt.Errorf("bad metadata, domains should be a map")
+						sendErr(fmt.Errorf("bad metadata, domains should be a map"))
 						return
 					}
 				} else {
-					errChan <- fmt.Errorf("bad metadata, no domains key in metadata")
+					sendErr(fmt.Errorf("bad metadata, no domains key in metadata"))
 					return
 				}
 			}
@@ -96,7 +111,10 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 			for _, name := range req.ResourceNames {
 				// this is an ack
 				if reqChan, ok := dispatch[name]; ok {
-					reqChan <- req
+					select {
+					case reqChan <- req:
+					case <-ctx.Done():
+					}
 					continue
 				}
 
@@ -107,21 +125,21 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 							if v, ok := v.(string); ok {
 								domains = append(domains, v)
 							} else {
-								errChan <- fmt.Errorf("bad metadata, domain should be string")
+								sendErr(fmt.Errorf("bad metadata, domain should be string"))
 								return
 							}
 						}
 					} else {
-						errChan <- fmt.Errorf("bad metadata, domain pack should be an array")
+						sendErr(fmt.Errorf("bad metadata, domain pack should be an array"))
 						return
 					}
 					if !domain.AllAllowed(sds.cdxsrv.Config.ACME.AllowedDomains, domains) {
-						errChan <- fmt.Errorf("domains %v: %w", domains, domain.ErrNotAllowed)
+						sendErr(fmt.Errorf("domains %v: %w", domains, domain.ErrNotAllowed))
 						return
 					}
 					packRequests[name] = domains
 				} else {
-					errChan <- fmt.Errorf("bad metadata, missing domain names for pack %s", name)
+					sendErr(fmt.Errorf("bad metadata, missing domain names for pack %s", name))
 					return
 				}
 			}
@@ -190,7 +208,8 @@ func (sds *MySDS) handleCert(ctx context.Context, name string, entry *certEntry,
 		})
 
 		if err != nil {
-			logging.Panic("Unexpected error constructing response, err: %s", err)
+			logging.Error("Failed to construct SDS response: %s", err)
+			return
 		}
 
 		version := cert.RenewAt.Format(time.RFC3339)
@@ -203,6 +222,7 @@ func (sds *MySDS) handleCert(ctx context.Context, name string, entry *certEntry,
 		}:
 		case <-ctx.Done():
 			logging.Debug("Message sender stopped due to ctx done: %s", ctx.Err())
+			return
 		}
 
 		logging.Info("Offered cert %v version %s to %s", entry.domains, version, peer)
@@ -219,6 +239,7 @@ func (sds *MySDS) handleCert(ctx context.Context, name string, entry *certEntry,
 			}
 		case <-ctx.Done():
 			logging.Debug("Message sender stopped due to ctx done: %s", ctx.Err())
+			return
 		}
 
 		seen = entry.WaitForUpdate(ctx, seen)
@@ -245,11 +266,16 @@ func clientTLSLog(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo,
 }
 
 // SDSSrv runs the gRPC SDS endpoint until Stop is called.
-func (s *CertDXServer) SDSSrv() {
+func (s *CertDXServer) SDSSrv() error {
 	logging.Info("Start listening GRPC at %s", s.Config.GRPCSDSServer.Listen)
 
+	mtlsConfig, err := getMtlsConfig()
+	if err != nil {
+		return err
+	}
+
 	server := grpc.NewServer(
-		grpc.Creds(credentials.NewTLS(getMtlsConfig())),
+		grpc.Creds(credentials.NewTLS(mtlsConfig)),
 		grpc.UnaryInterceptor(clientTLSLog),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             time.Second,
@@ -267,20 +293,30 @@ func (s *CertDXServer) SDSSrv() {
 	}
 	secretv3.RegisterSecretDiscoveryServiceServer(server, sds)
 
+	l, err := net.Listen("tcp", s.Config.GRPCSDSServer.Listen)
+	if err != nil {
+		return fmt.Errorf("listen at %s: %w", s.Config.GRPCSDSServer.Listen, err)
+	}
+
+	errChan := make(chan error, 1)
 	go func() {
-		l, err := net.Listen("tcp", s.Config.GRPCSDSServer.Listen)
-		if err != nil {
-			logging.Fatal("Failed to listen at %s, err: %s", s.Config.GRPCSDSServer.Listen, err)
-		}
 		logging.Info("SDS server started")
 		if err := server.Serve(l); err != nil {
-			logging.Fatal("%s", err)
+			errChan <- err
+			return
 		}
+		errChan <- nil
 	}()
 
-	<-s.rootCtx.Done()
-
-	close(sds.kill)
-	server.GracefulStop()
+	select {
+	case err := <-errChan:
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			return fmt.Errorf("serve SDS: %w", err)
+		}
+	case <-s.rootCtx.Done():
+		close(sds.kill)
+		server.GracefulStop()
+	}
 	logging.Info("SDS Stopped")
+	return nil
 }


### PR DESCRIPTION
## Summary
- remove server package `logging.Fatal`/`Panic` paths from HTTP/SDS/mTLS startup code
- make `HttpSrv` and `SDSSrv` return errors to `exec/server`
- use per-server `ServeMux` instead of global `http.HandleFunc`
- use ctx-aware HTTP shutdown and graceful SDS shutdown
- flush queued cert-store updates before the writer exits on server stop
- add defensive SDS peer/metadata send handling where touched

Closes #16

## Verification
- `go test ./pkg/server`
- `go build ./...`
- `go vet ./...`
- `(cd exec/server && go build ./... && go vet ./...)`
- `(cd exec/caddytls && go build ./... && go vet ./...)`
- `go test -tags=e2e -count=1 -timeout=10m -race -v ./...` from `test/e2e`
- `git diff --check`
