### PR TITLE
fix: make grpc client shutdown ctx-safe

### DIFF
--- a/pkg/client/grpc_streamer.go
+++ b/pkg/client/grpc_streamer.go
@@ -76,7 +76,13 @@ func (s *grpcStreamer) run() {
 	defer s.sessionCancel()
 
 	for {
-		state := <-s.stateChan
+		var state GRPC_CLIENT_STATE
+		select {
+		case state = <-s.stateChan:
+		case <-s.daemon.rootCtx.Done():
+			s.sessionCancel()
+			return
+		}
 		logging.Debug("Process grpc client state: %d", state)
 		switch state {
 		case GRPC_STATE_STOP:
@@ -93,15 +99,24 @@ func (s *grpcStreamer) run() {
 			s.standbyActive.Store(true)
 			s.daemon.wg.Add(1)
 			go s.handleFailover()
-			s.stateChan <- GRPC_STATE_TRY_FALLBACK
+			s.sendState(GRPC_STATE_TRY_FALLBACK)
 		case GRPC_STATE_TRY_FALLBACK:
 			s.daemon.wg.Add(1)
 			go s.handleFallback(s.sessionCtx, s.sessionCancel)
-			s.stateChan <- GRPC_STATE_RESTART_MAIN
+			s.sendState(GRPC_STATE_RESTART_MAIN)
 		case GRPC_STATE_RESTART_MAIN:
 			s.daemon.wg.Add(1)
 			go s.handleRestart(s.sessionCtx)
 		}
+	}
+}
+
+func (s *grpcStreamer) sendState(state GRPC_CLIENT_STATE) bool {
+	select {
+	case s.stateChan <- state:
+		return true
+	case <-s.daemon.rootCtx.Done():
+		return false
 	}
 }
 
@@ -112,15 +127,15 @@ func (s *grpcStreamer) run() {
 func (s *grpcStreamer) handleMain() {
 	defer func() {
 		s.daemon.wg.Done()
-		logging.Debug("Main stream gorountine exit")
+		logging.Debug("Main stream goroutine exit")
 	}()
 
 	logging.Info("Starting gRPC main stream")
 	startTime := time.Now()
-	err := s.mainClient.Stream()
+	err := s.mainClient.Stream(s.daemon.rootCtx)
 	logging.Info("gRPC main stream stopped: %s", err)
 	if _, ok := err.(*killed); ok {
-		s.stateChan <- GRPC_STATE_STOP
+		s.sendState(GRPC_STATE_STOP)
 		return
 	}
 
@@ -128,7 +143,7 @@ func (s *grpcStreamer) handleMain() {
 		s.mainRetryCount++
 	} else {
 		s.mainRetryCount = 0
-		s.stateChan <- GRPC_STATE_MAIN
+		s.sendState(GRPC_STATE_MAIN)
 		return
 	}
 
@@ -136,21 +151,21 @@ func (s *grpcStreamer) handleMain() {
 	if s.mainRetryCount < s.daemon.Config.Common.RetryCount {
 		select {
 		case <-time.After(grpcRetryBackoff):
-			s.stateChan <- GRPC_STATE_MAIN
+			s.sendState(GRPC_STATE_MAIN)
 			return
 		case <-s.daemon.rootCtx.Done():
 			return
 		}
 	}
 
-	logging.Info("Retry limite for main stream reached")
+	logging.Info("Retry limit for main stream reached")
 	s.mainRetryCount = 0
 	if s.standbyExists && !s.standbyActive.Load() {
 		logging.Info("Start trying standby stream")
-		s.stateChan <- GRPC_STATE_FAILOVER
+		s.sendState(GRPC_STATE_FAILOVER)
 	} else {
 		logging.Info("Sleep %s", s.daemon.Config.Common.ReconnectInterval)
-		s.stateChan <- GRPC_STATE_RESTART_MAIN
+		s.sendState(GRPC_STATE_RESTART_MAIN)
 	}
 }
 
@@ -171,7 +186,7 @@ func (s *grpcStreamer) handleFailover() {
 		}
 		logging.Info("Starting gRPC standby stream")
 		startTime := time.Now()
-		err := s.standbyClient.Stream()
+		err := s.standbyClient.Stream(s.sessionCtx)
 		logging.Info("gRPC standby stream stopped: %s", err)
 		if _, ok := err.(*killed); ok {
 			return
@@ -195,7 +210,7 @@ func (s *grpcStreamer) handleFailover() {
 			}
 		}
 
-		logging.Info("Retry limite for standby stream reached, sleep %s", s.daemon.Config.Common.ReconnectInterval)
+		logging.Info("Retry limit for standby stream reached, sleep %s", s.daemon.Config.Common.ReconnectInterval)
 		standbyRetryCount = 0
 		select {
 		case <-time.After(s.daemon.Config.Common.ReconnectDuration):
@@ -237,7 +252,7 @@ func (s *grpcStreamer) handleRestart(sessionCtx context.Context) {
 	logging.Debug("Reconnect duration is: %s", s.daemon.Config.Common.ReconnectDuration)
 	select {
 	case <-time.After(s.daemon.Config.Common.ReconnectDuration):
-		s.stateChan <- GRPC_STATE_MAIN
+		s.sendState(GRPC_STATE_MAIN)
 	case <-sessionCtx.Done():
 		logging.Debug("Restart goroutine reset")
 		return
@@ -256,11 +271,11 @@ func (r *CertDXClientDaemon) GRPCMain() {
 	r.wg.Add(1)
 	go s.run()
 
-	s.stateChan <- GRPC_STATE_MAIN
+	s.sendState(GRPC_STATE_MAIN)
 
 	<-r.rootCtx.Done()
 
-	s.stateChan <- GRPC_STATE_STOP
+	s.sendState(GRPC_STATE_STOP)
 
 	logging.Info("Stopping gRPC client")
 	s.mainClient.Kill()

--- a/pkg/client/sds.go
+++ b/pkg/client/sds.go
@@ -43,8 +43,8 @@ type CertDXgRPCClient struct {
 	server  *config.ClientGRPCServer
 	certs   map[domain.Key]*watchingCert
 
-	kill    chan struct{}
 	Running atomic.Bool
+	cancel  atomic.Pointer[context.CancelFunc]
 
 	// Received is closed by the receive loop on each incoming message
 	// and replaced atomically with a fresh chan, so the fallback
@@ -58,7 +58,6 @@ func MakeCertDXgRPCClient(server *config.ClientGRPCServer, certs map[domain.Key]
 	c := &CertDXgRPCClient{
 		server: server,
 		certs:  certs,
-		kill:   make(chan struct{}),
 	}
 	received := make(chan struct{})
 	c.Received.Store(&received)
@@ -67,12 +66,20 @@ func MakeCertDXgRPCClient(server *config.ClientGRPCServer, certs map[domain.Key]
 	return c
 }
 
-func (c *CertDXgRPCClient) Stream() error {
+func sendStreamErr(ctx context.Context, errChan chan<- error, err error) {
 	select {
-	case <-c.kill:
-		return &killed{Err: "stream killed"}
-	default:
+	case errChan <- err:
+	case <-ctx.Done():
 	}
+}
+
+func (c *CertDXgRPCClient) Stream(ctx context.Context) error {
+	streamCtx, cancel := context.WithCancel(ctx)
+	c.cancel.Store(&cancel)
+	defer func() {
+		cancel()
+		c.cancel.Store(nil)
+	}()
 
 	c.Running.Store(true)
 	conn, err := grpc.NewClient(c.server.Server,
@@ -92,15 +99,15 @@ func (c *CertDXgRPCClient) Stream() error {
 	}()
 
 	client := secretv3.NewSecretDiscoveryServiceClient(conn)
-	stream, err := client.StreamSecrets(context.Background())
+	stream, err := client.StreamSecrets(streamCtx)
 	if err != nil {
 		return fmt.Errorf("stream secrets failed: %w", err)
 	}
-	ctx := stream.Context()
+	ctx = stream.Context()
 
 	dispatch := map[string]chan respData{}
 	ack := make(chan *discoveryv3.DiscoveryRequest)
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 
 	for _, cert := range c.certs {
 		dispatch[cert.Config.Name] = make(chan respData)
@@ -119,7 +126,11 @@ func (c *CertDXgRPCClient) Stream() error {
 
 			resp, err := stream.Recv()
 			if err != nil {
-				errChan <- fmt.Errorf("failed receiving request: %w", err)
+				sendStreamErr(ctx, errChan, fmt.Errorf("failed receiving request: %w", err))
+				return
+			}
+			if len(resp.Resources) == 0 {
+				sendStreamErr(ctx, errChan, fmt.Errorf("SDS response has no resources"))
 				return
 			}
 			newReceived := make(chan struct{})
@@ -128,19 +139,22 @@ func (c *CertDXgRPCClient) Stream() error {
 			secretResp := &tlsv3.Secret{}
 			err = anypb.UnmarshalTo(resp.Resources[0], secretResp, proto.UnmarshalOptions{})
 			if err != nil {
-				errChan <- fmt.Errorf("can not unmarshal message from srv: %w", err)
+				sendStreamErr(ctx, errChan, fmt.Errorf("can not unmarshal message from srv: %w", err))
 				return
 			}
 
 			respChan, ok := dispatch[secretResp.Name]
 			if !ok {
-				errChan <- fmt.Errorf("unexcepted cert: %s", secretResp.Name)
+				sendStreamErr(ctx, errChan, fmt.Errorf("unexpected cert: %s", secretResp.Name))
 				return
 			}
 
-			respChan <- respData{
+			select {
+			case respChan <- respData{
 				Version: resp.VersionInfo,
 				Secret:  secretResp,
+			}:
+			case <-ctx.Done():
 			}
 		}
 	}()
@@ -162,7 +176,7 @@ func (c *CertDXgRPCClient) Stream() error {
 			domainKey: domainSets,
 		})
 		if err != nil {
-			errChan <- fmt.Errorf("failed constructing meta data struct: %w", err)
+			sendStreamErr(ctx, errChan, fmt.Errorf("failed constructing meta data struct: %w", err))
 			return
 		}
 
@@ -176,7 +190,7 @@ func (c *CertDXgRPCClient) Stream() error {
 
 		err = stream.Send(packReq)
 		if err != nil {
-			errChan <- fmt.Errorf("failed sending request: %w", err)
+			sendStreamErr(ctx, errChan, fmt.Errorf("failed sending request: %w", err))
 			return
 		}
 
@@ -185,7 +199,7 @@ func (c *CertDXgRPCClient) Stream() error {
 			case a := <-ack:
 				if err := stream.Send(a); err != nil {
 					// a failed in sending should make the context fail as well.
-					errChan <- fmt.Errorf("failed sending ack: %w", err)
+					sendStreamErr(ctx, errChan, fmt.Errorf("failed sending ack: %w", err))
 					return
 				}
 			case <-ctx.Done():
@@ -202,9 +216,6 @@ func (c *CertDXgRPCClient) Stream() error {
 	case err := <-errChan:
 		logging.Error("Stream end due to errored: %s", err)
 		return err
-	case <-c.kill:
-		logging.Debug("Stream end due to explicit kill.")
-		return &killed{Err: "stream killed"}
 	}
 }
 
@@ -216,20 +227,28 @@ func (c *CertDXgRPCClient) handleCert(ctx context.Context, cert *watchingCert,
 		case _respData := <-resp:
 			respCert, ok := _respData.Secret.Type.(*tlsv3.Secret_TlsCertificate)
 			if !ok {
-				errChan <- fmt.Errorf("unexcepted resp type")
+				sendStreamErr(ctx, errChan, fmt.Errorf("unexpected resp type"))
 				return
 			}
 
-			cert.UpdateChan <- certData{
+			select {
+			case cert.UpdateChan <- certData{
 				Domains:   cert.Config.Domains,
 				Fullchain: respCert.TlsCertificate.CertificateChain.GetInlineBytes(),
 				Key:       respCert.TlsCertificate.PrivateKey.GetInlineBytes(),
+			}:
+			case <-ctx.Done():
+				return
 			}
 
-			ack <- &discoveryv3.DiscoveryRequest{
+			select {
+			case ack <- &discoveryv3.DiscoveryRequest{
 				TypeUrl:       typeUrl,
 				VersionInfo:   _respData.Version,
 				ResourceNames: []string{cert.Config.Name},
+			}:
+			case <-ctx.Done():
+				return
 			}
 		case <-ctx.Done():
 			logging.Debug("handler stopped due to ctx done: %s", ctx.Err())
@@ -239,8 +258,7 @@ func (c *CertDXgRPCClient) handleCert(ctx context.Context, cert *watchingCert,
 }
 
 func (c *CertDXgRPCClient) Kill() {
-	if c.Running.Load() {
-		close(c.kill)
-		c.kill = make(chan struct{})
+	if cancel := c.cancel.Load(); cancel != nil {
+		(*cancel)()
 	}
 }


### PR DESCRIPTION
## Summary

Closes task #17.

- `CertDXgRPCClient.Stream` now takes a parent context and streams with a derived cancellable context
- `Kill()` cancels the active stream instead of closing/replacing a shared channel
- gRPC state transitions use ctx-aware sends so Stop cannot block on `stateChan`
- stream goroutines use buffered/ctx-guarded error sends and ctx-guarded cert/ack sends
- guard empty SDS responses before indexing `resp.Resources[0]`
- fix grpc shutdown log typos while touching the file

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -tags=e2e -count=1 -timeout=10m -race -run 'TestGRPC' -v ./...` from `test/e2e`
- `git diff --check`
