### PR TITLE
fix: remove logging.Fatal from pkg/client/mtls.go (audit PR 7)

### DIFF
--- a/exec/caddytls/certdx.go
+++ b/exec/caddytls/certdx.go
@@ -122,14 +122,18 @@ func (m *CertDXCaddyDaemon) Start() error {
 			return fmt.Errorf("http main_server url is required")
 		}
 		m.wg.Go(func() {
-			m.certDXDaemon.HttpMain()
+			if err := m.certDXDaemon.HttpMain(); err != nil {
+				caddy.Log().Named("certdx").Error("http daemon exited with error", zap.Error(err))
+			}
 		})
 	case config.CLIENT_MODE_GRPC:
 		if m.certDXDaemon.Config.GRPC.MainServer.Server == "" {
 			return fmt.Errorf("grpc main_server is required")
 		}
 		m.wg.Go(func() {
-			m.certDXDaemon.GRPCMain()
+			if err := m.certDXDaemon.GRPCMain(); err != nil {
+				caddy.Log().Named("certdx").Error("grpc daemon exited with error", zap.Error(err))
+			}
 		})
 	default:
 		return fmt.Errorf("unsupported mode %q", mode)

--- a/exec/client/main.go
+++ b/exec/client/main.go
@@ -63,12 +63,16 @@ func init() {
 func main() {
 	go cli.WaitForShutdown(certDXDaemon.Stop, shutdownTimeout)
 
+	var err error
 	switch certDXDaemon.Config.Common.Mode {
 	case config.CLIENT_MODE_HTTP:
-		certDXDaemon.HttpMain()
+		err = certDXDaemon.HttpMain()
 	case config.CLIENT_MODE_GRPC:
-		certDXDaemon.GRPCMain()
+		err = certDXDaemon.GRPCMain()
 	default:
 		logging.Fatal("Mode: \"%s\" is not supported", certDXDaemon.Config.Common.Mode)
+	}
+	if err != nil {
+		logging.Fatal("Daemon exited with error: %s", err)
 	}
 }

--- a/exec/tools/tasks/kubernetesCertificateUpdater/updater.go
+++ b/exec/tools/tasks/kubernetesCertificateUpdater/updater.go
@@ -188,20 +188,29 @@ func (r *KubernetesCertificateUpdater) registerWatchAndHandlers(ctx context.Cont
 }
 
 func (r *KubernetesCertificateUpdater) startCertDXDaemon() error {
+	var run func() error
 	switch r.certDXDaemon.Config.Common.Mode {
 	case config.CLIENT_MODE_HTTP:
 		if r.certDXDaemon.Config.Http.MainServer.Url == "" {
 			return fmt.Errorf("http main server url should not be empty")
 		}
-		go r.certDXDaemon.HttpMain()
+		run = r.certDXDaemon.HttpMain
 	case config.CLIENT_MODE_GRPC:
 		if r.certDXDaemon.Config.GRPC.MainServer.Server == "" {
 			return fmt.Errorf("GRPC main server url should not be empty")
 		}
-		go r.certDXDaemon.GRPCMain()
+		run = r.certDXDaemon.GRPCMain
 	default:
 		return fmt.Errorf("not supported mode: %s", r.certDXDaemon.Config.Common.Mode)
 	}
+	go func() {
+		if err := run(); err != nil {
+			logging.Error("Daemon exited with error: %s", err)
+			// Cancel the daemon so the outer waitReplaceTask wakes up
+			// instead of hanging on its deadline.
+			r.certDXDaemon.Stop()
+		}
+	}()
 	return nil
 }
 

--- a/exec/tools/tasks/kubernetesCertificateUpdater/updater.go
+++ b/exec/tools/tasks/kubernetesCertificateUpdater/updater.go
@@ -40,6 +40,12 @@ type KubernetesCertificateUpdater struct {
 
 	certDXDaemon *client.CertDXClientDaemon
 	kubeClient   kubernetes.Interface
+
+	// daemonErr is written exactly once by the goroutine that runs
+	// HttpMain / GRPCMain if the daemon fails to start (e.g. invalid
+	// mtls material). waitReplaceTask selects on it so an init failure
+	// surfaces immediately instead of hanging until waitDeadline.
+	daemonErr chan error
 }
 
 func MakeKubernetesReplaceCertificate(updaterCmd *k8sCertsUpdateCmd) *KubernetesCertificateUpdater {
@@ -48,6 +54,7 @@ func MakeKubernetesReplaceCertificate(updaterCmd *k8sCertsUpdateCmd) *Kubernetes
 
 		wg:           sync.WaitGroup{},
 		taskErrMutex: sync.Mutex{},
+		daemonErr:    make(chan error, 1),
 
 		// certDXDaemon : in certdx init
 	}
@@ -205,9 +212,13 @@ func (r *KubernetesCertificateUpdater) startCertDXDaemon() error {
 	}
 	go func() {
 		if err := run(); err != nil {
-			logging.Error("Daemon exited with error: %s", err)
-			// Cancel the daemon so the outer waitReplaceTask wakes up
-			// instead of hanging on its deadline.
+			// Surface the error to waitReplaceTask via daemonErr (so
+			// init failures do not silently hang the outer wait), then
+			// cancel the daemon so any other watchers wind down.
+			select {
+			case r.daemonErr <- err:
+			default:
+			}
 			r.certDXDaemon.Stop()
 		}
 	}()
@@ -225,6 +236,8 @@ func (r *KubernetesCertificateUpdater) waitReplaceTask() error {
 	}()
 
 	select {
+	case err := <-r.daemonErr:
+		return fmt.Errorf("certdx daemon failed: %w", err)
 	case <-waitCtx.Done():
 		return fmt.Errorf("timeout waiting for kubernetes secrets to be updated")
 	case <-wgDone:

--- a/pkg/client/grpc_streamer.go
+++ b/pkg/client/grpc_streamer.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -55,18 +56,26 @@ type grpcStreamer struct {
 	sessionCancel context.CancelFunc
 }
 
-func newGRPCStreamer(d *CertDXClientDaemon) *grpcStreamer {
+func newGRPCStreamer(d *CertDXClientDaemon) (*grpcStreamer, error) {
+	mainClient, err := MakeCertDXgRPCClient(&d.Config.GRPC.MainServer, d.certs)
+	if err != nil {
+		return nil, fmt.Errorf("construct main grpc client: %w", err)
+	}
 	s := &grpcStreamer{
 		daemon:        d,
-		mainClient:    MakeCertDXgRPCClient(&d.Config.GRPC.MainServer, d.certs),
+		mainClient:    mainClient,
 		standbyExists: d.Config.GRPC.StandbyServer.Server != "",
 		stateChan:     make(chan GRPC_CLIENT_STATE, 1),
 	}
 	if s.standbyExists {
-		s.standbyClient = MakeCertDXgRPCClient(&d.Config.GRPC.StandbyServer, d.certs)
+		standbyClient, err := MakeCertDXgRPCClient(&d.Config.GRPC.StandbyServer, d.certs)
+		if err != nil {
+			return nil, fmt.Errorf("construct standby grpc client: %w", err)
+		}
+		s.standbyClient = standbyClient
 	}
 	s.sessionCtx, s.sessionCancel = context.WithCancel(d.rootCtx)
-	return s
+	return s, nil
 }
 
 // run is the dispatch loop. It reads state transitions off stateChan
@@ -262,11 +271,16 @@ func (s *grpcStreamer) handleRestart(sessionCtx context.Context) {
 // GRPCMain runs the gRPC SDS client (with failover) until Stop is
 // called. The five-state machine and its state transitions are
 // preserved; encapsulating it in grpcStreamer just makes the
-// dispatch loop and per-state logic easier to read.
-func (r *CertDXClientDaemon) GRPCMain() {
-	r.startWatchers()
+// dispatch loop and per-state logic easier to read. Returns an error
+// if the streamer cannot be constructed (e.g. mtls material missing
+// or invalid); a non-nil return means the daemon never started.
+func (r *CertDXClientDaemon) GRPCMain() error {
+	s, err := newGRPCStreamer(r)
+	if err != nil {
+		return err
+	}
 
-	s := newGRPCStreamer(r)
+	r.startWatchers()
 
 	r.wg.Add(1)
 	go s.run()
@@ -283,4 +297,5 @@ func (r *CertDXClientDaemon) GRPCMain() {
 		s.standbyClient.Kill()
 	}
 	r.wg.Wait()
+	return nil
 }

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -18,31 +18,40 @@ type CertDXHttpClient struct {
 	Server     *config.ClientHttpServer
 }
 
-type CertDXHttpClientOption func(client *CertDXHttpClient)
+// CertDXHttpClientOption configures a CertDXHttpClient. Returning an
+// error lets options that do real I/O (e.g. loading mtls material) fail
+// the construction of the client instead of logging.Fatal-ing inside.
+type CertDXHttpClientOption func(client *CertDXHttpClient) error
 
 func WithCertDXServerInfo(server *config.ClientHttpServer) CertDXHttpClientOption {
-	return func(client *CertDXHttpClient) {
+	return func(client *CertDXHttpClient) error {
 		client.Server = server
 
 		if server.AuthMethod == config.HTTP_AUTH_MTLS {
+			cfg, err := getMtlsConfig(server.CA, server.Certificate, server.Key)
+			if err != nil {
+				return fmt.Errorf("configure mtls for %s: %w", server.Url, err)
+			}
 			client.HttpClient.Transport = &http.Transport{
-				TLSClientConfig: getMtlsConfig(server.CA, server.Certificate, server.Key),
+				TLSClientConfig: cfg,
 			}
 		}
+		return nil
 	}
 }
 
 func WithCertDXInsecure() CertDXHttpClientOption {
-	return func(client *CertDXHttpClient) {
+	return func(client *CertDXHttpClient) error {
 		client.HttpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
 		}
+		return nil
 	}
 }
 
-func MakeCertDXHttpClient(s ...CertDXHttpClientOption) *CertDXHttpClient {
+func MakeCertDXHttpClient(s ...CertDXHttpClientOption) (*CertDXHttpClient, error) {
 	ret := &CertDXHttpClient{
 		HttpClient: &http.Client{
 			Timeout: 30 * time.Second,
@@ -50,10 +59,12 @@ func MakeCertDXHttpClient(s ...CertDXHttpClientOption) *CertDXHttpClient {
 	}
 
 	for _, item := range s {
-		item(ret)
+		if err := item(ret); err != nil {
+			return nil, err
+		}
 	}
 
-	return ret
+	return ret, nil
 }
 
 func (c *CertDXHttpClient) makeGetCertRequest(ctx context.Context, domains []string) (*http.Request, error) {

--- a/pkg/client/http_poller.go
+++ b/pkg/client/http_poller.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"time"
 
 	"pkg.para.party/certdx/pkg/api"
@@ -14,8 +15,10 @@ import (
 func (r *CertDXClientDaemon) httpRequestCert(domains []string) *api.HttpCertResp {
 	var resp *api.HttpCertResp
 	err := retry.Do(r.rootCtx, r.Config.Common.RetryCount, func() error {
-		certdxClient := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(&r.Config.Http.MainServer))...)
-		var err error
+		certdxClient, err := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(&r.Config.Http.MainServer))...)
+		if err != nil {
+			return fmt.Errorf("construct main http client: %w", err)
+		}
 		resp, err = certdxClient.GetCertCtx(r.rootCtx, domains)
 		return err
 	})
@@ -25,9 +28,11 @@ func (r *CertDXClientDaemon) httpRequestCert(domains []string) *api.HttpCertResp
 	logging.Warn("Failed to get cert %v from MainServer, err: %s", domains, err)
 
 	if r.Config.Http.StandbyServer.Url != "" {
-		certdxClient := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(&r.Config.Http.StandbyServer))...)
 		err = retry.Do(r.rootCtx, r.Config.Common.RetryCount, func() error {
-			var err error
+			certdxClient, err := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(&r.Config.Http.StandbyServer))...)
+			if err != nil {
+				return fmt.Errorf("construct standby http client: %w", err)
+			}
 			resp, err = certdxClient.GetCertCtx(r.rootCtx, domains)
 			return err
 		})
@@ -79,8 +84,10 @@ func (r *CertDXClientDaemon) httpPollingCert(cert *watchingCert) {
 
 // HttpMain runs the HTTP polling client until Stop is called. It
 // launches one watchUpdate + one httpPollingCert per registered cert
-// and blocks until rootCtx is done.
-func (r *CertDXClientDaemon) HttpMain() {
+// and blocks until rootCtx is done. Returns nil today; the signature
+// matches GRPCMain so the entry-point dispatch is uniform and a
+// future http-side init failure can be surfaced the same way.
+func (r *CertDXClientDaemon) HttpMain() error {
 	r.startWatchers()
 
 	for _, c := range r.certs {
@@ -95,4 +102,5 @@ func (r *CertDXClientDaemon) HttpMain() {
 
 	logging.Info("Stopping Http client")
 	r.wg.Wait()
+	return nil
 }

--- a/pkg/client/mtls.go
+++ b/pkg/client/mtls.go
@@ -3,25 +3,28 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
-
-	"pkg.para.party/certdx/pkg/logging"
 )
 
-func getMtlsConfig(CA, certificate, key string) *tls.Config {
+// getMtlsConfig builds the gRPC / HTTP mTLS client TLS config from the
+// CA, certificate, and key on disk. Each step returns a wrapped error
+// instead of `logging.Fatal`-ing so the daemon entry point can decide
+// whether to abort, retry, or surface the failure to its caller.
+func getMtlsConfig(CA, certificate, key string) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(certificate, key)
 	if err != nil {
-		logging.Fatal("Invalid gRPC client cert, err: %s", err)
+		return nil, fmt.Errorf("load mtls client certificate: %w", err)
 	}
 
 	caPEM, err := os.ReadFile(CA)
 	if err != nil {
-		logging.Fatal("err: %s", err)
+		return nil, fmt.Errorf("read mtls ca certificate: %w", err)
 	}
 
 	capool := x509.NewCertPool()
 	if !capool.AppendCertsFromPEM(caPEM) {
-		logging.Fatal("Invalid ca cert")
+		return nil, fmt.Errorf("parse mtls ca certificate")
 	}
 
 	return &tls.Config{
@@ -29,5 +32,5 @@ func getMtlsConfig(CA, certificate, key string) *tls.Config {
 		RootCAs:      capool,
 		MinVersion:   tls.VersionTLS13,
 		MaxVersion:   tls.VersionTLS13,
-	}
+	}, nil
 }

--- a/pkg/client/sds.go
+++ b/pkg/client/sds.go
@@ -54,16 +54,21 @@ type CertDXgRPCClient struct {
 	Received atomic.Pointer[chan struct{}]
 }
 
-func MakeCertDXgRPCClient(server *config.ClientGRPCServer, certs map[domain.Key]*watchingCert) *CertDXgRPCClient {
+func MakeCertDXgRPCClient(server *config.ClientGRPCServer, certs map[domain.Key]*watchingCert) (*CertDXgRPCClient, error) {
+	cfg, err := getMtlsConfig(server.CA, server.Certificate, server.Key)
+	if err != nil {
+		return nil, fmt.Errorf("configure mtls for %s: %w", server.Server, err)
+	}
+
 	c := &CertDXgRPCClient{
-		server: server,
-		certs:  certs,
+		server:  server,
+		certs:   certs,
+		tlsCred: credentials.NewTLS(cfg),
 	}
 	received := make(chan struct{})
 	c.Received.Store(&received)
 	c.Running.Store(false)
-	c.tlsCred = credentials.NewTLS(getMtlsConfig(server.CA, server.Certificate, server.Key))
-	return c
+	return c, nil
 }
 
 func sendStreamErr(ctx context.Context, errChan chan<- error, err error) {


### PR DESCRIPTION
## Summary

Audit PR 7 (task #19). Removes `logging.Fatal` from `pkg/client/mtls.go` and propagates errors up through the client construction chain.

## Bug

`getMtlsConfig` called `logging.Fatal` on every failure path (missing cert/key, missing CA, parse failure). That bypassed normal shutdown, killed every other goroutine mid-flight, and gave callers no chance to surface a meaningful error to operators.

## Fix

- `getMtlsConfig` returns `(*tls.Config, error)`; each failure path returns a wrapped error.
- `MakeCertDXgRPCClient` returns `(*CertDXgRPCClient, error)` and builds the tls.Config inside.
- `CertDXHttpClientOption` is now `func(*CertDXHttpClient) error`; `WithCertDXServerInfo` propagates mtls errors and `MakeCertDXHttpClient` short-circuits on the first option failure.
- `newGRPCStreamer` returns an error if either client fails to construct, so a bad mtls config is surfaced before the failover state machine starts.
- `GRPCMain` and `HttpMain` now return error so init failures bubble up to entry points:
  - `exec/client/main.go`: `logging.Fatal`s only at the top level on a non-nil return.
  - `exec/caddytls/certdx.go`: logs through caddy's named logger.
  - k8s updater: wraps the goroutine to log + `Stop()` so the outer wait unblocks instead of hanging on its deadline.
- `pkg/client/http_poller.go` propagates `MakeCertDXHttpClient` errors through the per-server retry callback.

## Out of scope

The txc updater (task #14 / #59 still in review) is intentionally not touched here to keep this PR conflict-free; once #59 lands the same goroutine wrapping pattern can be applied there in a follow-up.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean (root + `exec/tools` + `exec/caddytls`)
- [x] `go test -race -count=1 -tags=e2e -timeout=600s ./test/e2e/...` — passed (~253s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)