### PR TITLE
fix: standardize log message wording (audit PR 8)

### DIFF
--- a/exec/server/main.go
+++ b/exec/server/main.go
@@ -56,11 +56,11 @@ func init() {
 	}
 
 	if err := cdxsrv.Config.Validate(); err != nil {
-		logging.Fatal("Invalid config, err: %v", err)
+		logging.Fatal("Invalid config: %v", err)
 	}
 
 	if err := cdxsrv.Init(); err != nil {
-		logging.Fatal("Failed to init certdx server, err: %s", err)
+		logging.Fatal("Failed to init certdx server: %s", err)
 	}
 }
 

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -84,12 +84,12 @@ func writeCertAndDoCommand(fullchain, key []byte, c *config.ClientCertification)
 		args := strings.Fields(c.ReloadCommand)
 		err := exec.Command(args[0], args[1:]...).Run()
 		if err != nil {
-			logging.Error("Failed executing command %s, err: %s", c.ReloadCommand, err)
+			logging.Error("Failed executing command %s: %s", c.ReloadCommand, err)
 		}
 	}
 
 	return
 
 ERR:
-	logging.Error("Failed to save cert file, err: %s", err)
+	logging.Error("Failed to save cert file: %s", err)
 }

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -55,7 +55,7 @@ func Do(ctx context.Context, retryCount int, work func() error) error {
 			return fmt.Errorf("errored too fast, give up retry. last error is: %w", err)
 		}
 
-		logging.Warn("Retry %d/%d errored, err: %s", attempt, retryCount, err)
+		logging.Warn("Retry %d/%d errored: %s", attempt, retryCount, err)
 
 		if attempt >= retryCount {
 			break

--- a/pkg/server/cert_store.go
+++ b/pkg/server/cert_store.go
@@ -87,7 +87,7 @@ func (s *CertStore) listenUpdate(ctx context.Context) {
 		case fe := <-s.update:
 			logging.Info("Update domains cache to file")
 			if err := s.saveEntry(fe); err != nil {
-				logging.Warn("Update domains cache to file failed, err: %s", err)
+				logging.Warn("Update domains cache to file failed: %s", err)
 			}
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,12 +57,12 @@ func (s *CertDXServer) Init() error {
 
 	s.acme, err = acme.MakeACME(&s.Config)
 	if err != nil {
-		return fmt.Errorf("initailizing ACME failed: %w", err)
+		return fmt.Errorf("initialize ACME: %w", err)
 	}
 
 	if err = s.loadCertStore(); err != nil {
 		// It's okay that previous saved cert can not be loaded, just log and continue to run
-		logging.Warn("load cache file failed, err: %s", err)
+		logging.Warn("Load cache file failed: %s", err)
 	}
 	go s.certStore.listenUpdate(s.rootCtx)
 
@@ -92,7 +92,7 @@ func (s *CertDXServer) loadCertStore() error {
 	}
 	s.certCache.mutex.Unlock()
 
-	logging.Info("Previous cache loaded.")
+	logging.Info("Previous cache loaded")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Audit PR 8 (task #20). Narrow log/error wording sweep:

- Comma-style \"X failed, err: %s\" → colon-style \"X failed: %s\" or \"X: %s\" in:
  - `pkg/retry/retry.go`
  - `pkg/client/handler.go` (×2)
  - `pkg/server/server.go`
  - `pkg/server/cert_store.go`
  - `exec/server/main.go` (×2)
- `\"initailizing\"` → `\"initialize\"` in `(*CertDXServer).Init` error path.
- Sentence-case the lowercase warn message in `Init` (`load cache file failed` → `Load cache file failed`).
- Drop trailing period in `loadCertStore` info log.

## Out of scope

The same comma-style anti-pattern lives in `pkg/server/{http,sds,mtls}.go` and `pkg/client/{mtls,http_poller}.go`, but those files are being rewritten by PR #60 (client mtls Fatal removal) and PR #61 (server lifecycle hardening). Cleaning them up there avoids textual conflicts; this PR is intentionally narrow to files those PRs do not touch.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race -count=1 ./pkg/retry/...` (covers the only test for the format-string change)
- [x] `go test -race -count=1 -tags=e2e -timeout=600s ./test/e2e/...` — passed (~253s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)