### PR TITLE
fix: route HTTP allowlist rejection through domain.ErrNotAllowed (audit PR 9)

### DIFF
--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -80,10 +80,11 @@ func (s *CertDXServer) handleCertReq(w *http.ResponseWriter, r *http.Request) {
 	}
 
 	if !domain.AllAllowed(s.Config.ACME.AllowedDomains, req.Domains) {
-		logging.Warn("Requested domains not allowed: %v", req.Domains)
-		(*w).Header().Set("Content-Type", "application/json")
-		(*w).Write([]byte(`{ "err": "Domains not allowed" }`))
-		return
+		// Wrap the sentinel so the response handler below can branch on
+		// errors.Is — same pattern as the SDS path, instead of two
+		// separate "domains not allowed" code sites.
+		err = fmt.Errorf("domains %v: %w", req.Domains, domain.ErrNotAllowed)
+		goto ERR
 	}
 
 	cachedCert = s.certCache.get(req.Domains)
@@ -110,7 +111,13 @@ func (s *CertDXServer) handleCertReq(w *http.ResponseWriter, r *http.Request) {
 	return
 
 ERR:
-	logging.Error("Handle http cert request failed, err: %s", err)
+	if errors.Is(err, domain.ErrNotAllowed) {
+		logging.Warn("Requested domains not allowed: %v", req.Domains)
+		(*w).Header().Set("Content-Type", "application/json")
+		(*w).Write([]byte(`{ "err": "Domains not allowed" }`))
+		return
+	}
+	logging.Error("Handle http cert request failed: %s", err)
 	http.Error(*w, "", http.StatusInternalServerError)
 }
 


### PR DESCRIPTION
## Summary

Audit PR 9 (task #21). Wires the HTTP handler's allowlist-rejection path through the existing `domain.ErrNotAllowed` sentinel, matching the SDS path so both code sites emit the typed error.

## Before

- SDS: `sendStreamErr(ctx, errChan, fmt.Errorf("domains %v: %w", domains, domain.ErrNotAllowed))`
- HTTP: `(*w).Write([]byte(\`{ "err": "Domains not allowed" }\`))`

Two code sites for the same condition; future callers had no typed error to branch on.

## After

`handleCertReq` wraps the sentinel at the rejection site, routes through the existing `ERR` label, and the response handler does an `errors.Is(err, domain.ErrNotAllowed)` branch to emit the same JSON wire format.

## Wire contract

`{"err": "Domains not allowed"}` JSON body, status 200 — unchanged.

## Docs

`CONTEXT.md` already documents this as the canonical rejection path (\"rejected with `domain.ErrNotAllowed`\"); the audit just brings the HTTP code site into compliance with that description, no doc update needed. No api / config / behavior change.

## Test plan

- [x] `go build ./...` and `go vet ./...`
- [x] `go test -race -count=1 -tags=e2e -timeout=600s ./test/e2e/...` — passed (~254s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)