### PR TITLE
refactor: atomic cert/key writes (port handler.go from main-refactor)

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -97,6 +97,12 @@ The client polls the server on the same cadence as the server's renewal
 check (`ACME.renewTimeLeft / 4`). When the server returns a newer
 certificate, the client overwrites both files and runs `reloadCommand`.
 
+Writes are atomic via a temp-file-and-rename, so a downstream service
+reading the cert mid-update never observes a torn or partial file. The
+reload command runs only when both `<savePath>/<name>.pem` and `.key`
+already existed — the very first install is treated as a bootstrap
+where the downstream service is not yet up.
+
 ## Common validation errors
 
 - `no certification configured` — add at least one `[[Certifications]]`.

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,84 +11,112 @@ import (
 	"pkg.para.party/certdx/pkg/logging"
 )
 
-type CertificateUpdateHandler func(fullchain, key []byte, c *config.ClientCertification)
-
+// File permissions for written material.
 const (
-	certFileMode os.FileMode = 0o644
-	keyFileMode  os.FileMode = 0o600
+	permCertDir  os.FileMode = 0o755
+	permCertFile os.FileMode = 0o644
+	permKeyFile  os.FileMode = 0o600
 )
 
-func checkFileAndCreate(file string, fileMode os.FileMode) (exists bool, err error) {
-	exists = false
-	if _, err = os.Stat(file); os.IsNotExist(err) {
-		dir := filepath.Dir(file)
-		if _, err = os.Stat(dir); os.IsNotExist(err) {
-			err = os.MkdirAll(dir, 0o777)
-			if err != nil {
-				return
-			}
-		} else if err != nil {
-			return
-		}
+// CertificateUpdateHandler is invoked whenever a watched cert receives
+// fresh material. Handlers are expected to be quick; long-running work
+// should be dispatched elsewhere.
+type CertificateUpdateHandler func(fullchain, key []byte, c *config.ClientCertification)
 
-		err = os.WriteFile(file, []byte{}, fileMode)
-		if err != nil {
-			return
-		}
-		return
-	} else if err != nil {
-		return
+// ensureParentDir creates file's parent directory if needed. It reports
+// whether file already existed before we had the chance to write it.
+func ensureParentDir(file string) (exists bool, err error) {
+	if _, err = os.Stat(file); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
 	}
 
-	exists = true
-	return
+	dir := filepath.Dir(file)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, permCertDir); err != nil {
+			return false, fmt.Errorf("create %s: %w", dir, err)
+		}
+	} else if err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
+// writeFileAtomic writes data to path with the given mode using a
+// temp-file-then-rename dance, so readers (e.g. an nginx reloading the
+// cert) never observe a torn file.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".certdx-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		// If we never made it to rename, clean up the stray temp file.
+		_ = os.Remove(tmpName)
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s: %w", path, err)
+	}
+	return nil
+}
+
+// writeCertAndDoCommand persists fullchain/key to the paths configured
+// for c and invokes the optional reload command. File perms are tight:
+// 0o644 for the public cert, 0o600 for the private key. Writes are
+// atomic via rename, so partial-file reads are not possible.
+//
+// The reload command runs only when both files pre-existed; the first
+// install is effectively a bootstrap and the downstream service is
+// unlikely to be running yet.
 func writeCertAndDoCommand(fullchain, key []byte, c *config.ClientCertification) {
-	var doCommand, ce, ke bool
+	var certExists, keyExists bool
 
 	certPath, keyPath, err := c.GetFullChainAndKeyPath()
 	if err != nil {
-		logging.Debug("Failed to get full chain and key path")
+		logging.Debug("Failed to get cert save path: %s", err)
 		return
 	}
-
-	ce, err = checkFileAndCreate(certPath, certFileMode)
+	certExists, err = ensureParentDir(certPath)
+	if err != nil {
+		goto ERR
+	}
+	keyExists, err = ensureParentDir(keyPath)
 	if err != nil {
 		goto ERR
 	}
 
-	ke, err = checkFileAndCreate(keyPath, keyFileMode)
-	if err != nil {
+	if err = writeFileAtomic(certPath, fullchain, permCertFile); err != nil {
+		goto ERR
+	}
+	if err = writeFileAtomic(keyPath, key, permKeyFile); err != nil {
 		goto ERR
 	}
 
-	// if cert file is firstly created, don't do reload command
-	doCommand = ce && ke
-
-	err = os.WriteFile(certPath, fullchain, certFileMode)
-	if err != nil {
-		goto ERR
-	}
-
-	err = os.WriteFile(keyPath, key, keyFileMode)
-	if err != nil {
-		goto ERR
-	}
-
-	err = os.Chmod(keyPath, keyFileMode)
-	if err != nil {
-		goto ERR
-	}
-
-	if doCommand && c.ReloadCommand != "" {
-		args := strings.Fields(c.ReloadCommand)
-		err := exec.Command(args[0], args[1:]...).Run()
-		if err != nil {
-			logging.Error("Failed executing command %s: %s", c.ReloadCommand, err)
+	if certExists && keyExists {
+		// strings.Fields collapses whitespace and skips empty inputs, so
+		// a whitespace-only ReloadCommand returns an empty slice — guard
+		// against args[0] panicking instead of just !=  "".
+		if args := strings.Fields(c.ReloadCommand); len(args) > 0 {
+			if err = exec.Command(args[0], args[1:]...).Run(); err != nil {
+				logging.Error("Failed executing reload command %s: %s", c.ReloadCommand, err)
+			}
 		}
 	}
-
 	return
 
 ERR:


### PR DESCRIPTION
## Summary

Task #24. Port `pkg/client/handler.go` improvements from the `main-refactor` branch into current `main`.

## Bug

`writeCertAndDoCommand` used `os.WriteFile` for both the fullchain and the private key. If the process crashed mid-write, or a downstream service read the file between the two `os.WriteFile` calls, the consumer could observe a partial / torn file (cert without matching key, or vice versa). Same risk on a power loss during the write.

## Fix

- **`writeFileAtomic`**: temp-file-then-rename. Readers (e.g. an nginx reloading the cert) see either the old file or the fully-written new file — never a partial one.
- **`ensureParentDir`**: clearer split of \"does it exist already\" vs \"create the parent dir\" (the old `checkFileAndCreate` combined the two and also touched a zero-byte placeholder file pre-write, which served no purpose now that we rename).
- **Tighter dir permissions**: `0o755` instead of `0o777`.
- **Permission constants** renamed for consistency (`permCertDir` / `permCertFile` / `permKeyFile`).
- **Comments and error wrapping** updated to match the rest of the refactor.

Reload behavior is preserved: the reload command runs only when both files pre-existed (the first install is a bootstrap and the downstream service is unlikely to be up).

## Docs

`docs/client.md` \"Renewal cadence\" section now documents the atomic write guarantee plus the bootstrap-vs-rotation distinction for the reload command.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean (root + `exec/tools` + `exec/caddytls`)
- [x] `go test -race -count=1 -tags=e2e -timeout=600s ./test/e2e/...` — passed (~249s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)