### PR TITLE
build: add go.work + GOWORK=off for xcaddy + local-dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace file
-go.work
+# Go workspace file (committed for local-dev consistency across submodules)
+# go.work
 
 # Config file
 /*.toml

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,6 +99,35 @@ term enters the codebase.
 - **Counter**: the `mtls/counter.txt` file holding the next CA serial
   number. Only used by `certdx_tools make-server` / `make-client`.
 
+## Repository layout
+
+The repo is a Go workspace (`go.work` at the root) of six modules:
+
+- root (`pkg.para.party/certdx`) — the library packages under `pkg/`.
+- `exec/server`, `exec/client`, `exec/tools` — the standalone binaries.
+  Each has its own `go.mod` so heavy per-binary deps (e.g. k8s client in
+  `exec/tools`) stay out of the root module.
+- `exec/caddytls` — the Caddy plugin, kept as its own module so its
+  Caddy / certmagic dependency tree never leaks into the others.
+- `test/e2e` — the end-to-end harness, isolated so test deps stay out of
+  prod modules.
+
+Every submodule has a `replace pkg.para.party/certdx => ../..` directive
+for environments that don't load the workspace (e.g. xcaddy's temp
+build dir). For local development the `go.work` is what makes
+`go build ./...` from any subdirectory resolve `pkg.para.party/certdx`
+to the local checkout — no replace plumbing required.
+
+When iterating on the Caddy plugin, xcaddy must be told about the parent
+module explicitly (it does not honor `go.work`):
+
+    xcaddy build \
+      --with pkg.para.party/certdx/exec/caddytls=./exec/caddytls \
+      --replace pkg.para.party/certdx=./
+
+`release/build.py` does this for releases. See `docs/caddytls.md` for
+the full xcaddy invocation.
+
 ## Wire contracts (must-not-break)
 
 - **HTTP API**: `POST /` on the server with a JSON body

--- a/docs/caddytls.md
+++ b/docs/caddytls.md
@@ -14,8 +14,44 @@ that includes it with [`xcaddy`](https://github.com/caddyserver/xcaddy):
 xcaddy build --with pkg.para.party/certdx/exec/caddytls
 ```
 
+That pulls the published version of the plugin and the matching
+`pkg.para.party/certdx` core from the module proxy.
+
 Official release archives `caddy_certdx_<os>_<arch>` already ship a Caddy
 binary built with this plugin.
+
+### Building from a local checkout
+
+If you are iterating on the plugin or on `pkg.para.party/certdx` itself,
+point xcaddy at both the plugin source AND the parent module. The two
+flags are needed together — without `--replace`, xcaddy resolves the
+parent `pkg.para.party/certdx` import via the registry instead of your
+checkout, and you'll silently build against the published version:
+
+```sh
+GOWORK=off xcaddy build \
+  --with pkg.para.party/certdx/exec/caddytls=./exec/caddytls \
+  --replace pkg.para.party/certdx=./
+```
+
+`GOWORK=off` is required because xcaddy creates its temp build dir
+inside the repo (which sits in the `go.work` workspace). Without it,
+Go enters workspace mode and bypasses the `--replace` flags, leading
+to "cannot find module" failures or silent fallback to the registry
+version. `release/build.py --dev` sets this for you.
+
+To verify the resulting binary actually picked up your local code,
+inspect its embedded build metadata:
+
+```sh
+go version -m ./caddy | grep certdx
+```
+
+Both `pkg.para.party/certdx` and `pkg.para.party/certdx/exec/caddytls`
+should show `=> /path/to/your/checkout (devel)` — the `=>` line is
+the proof that `--replace` was honored. The recorded version may
+still read `vX.Y.Z` (the latest registry tag), but the bound source
+is from your checkout.
 
 ## Caddyfile syntax
 

--- a/go.work
+++ b/go.work
@@ -1,0 +1,10 @@
+go 1.26.2
+
+use (
+	.
+	./exec/caddytls
+	./exec/client
+	./exec/server
+	./exec/tools
+	./test/e2e
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -775,6 +775,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0 h1:dulLQAYQFYtG5MTplgNGHWuV2D+OBD+Z8lmDBmbLg+s=
 github.com/envoyproxy/go-control-plane v0.11.1 h1:wSUXTlLfiAQRWs2F+p+EKOY9rUyis1MyGqJ2DIk5HpM=
 github.com/envoyproxy/go-control-plane v0.11.1/go.mod h1:uhMcXKCQMEJHiAb0w+YGefQLaTEw+YhGluxZkrTmD0g=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
@@ -889,6 +890,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
@@ -912,6 +914,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt215EWcs98=
 github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
@@ -1410,7 +1413,6 @@ github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e h1:mOtuXaRAbVZsxAH
 github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
@@ -1858,6 +1860,7 @@ golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
 golang.org/x/tools v0.9.1 h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=
 golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -2018,6 +2021,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/release/build.py
+++ b/release/build.py
@@ -135,8 +135,14 @@ def main() -> None:
     # `-gcflags all=-N -l`, so the dev caddy binary is unstripped and
     # optimizer-friendly to attach a debugger to.
     caddy_env_extra = 'XCADDY_DEBUG=1 ' if dev_mode else ''
+    # GOWORK=off — xcaddy's temp build dir is created under release/, which
+    # lives inside the repo's go.work. Without this, Go enters workspace
+    # mode, finds ./exec/caddytls in the workspace, and bypasses the
+    # --replace directives we just passed (occasionally leading to
+    # "cannot find module" surprises). Setting GOWORK=off keeps xcaddy
+    # in module mode where the --replace flags actually take effect.
     subprocess.run(
-        f'''env {caddy_env_extra}GOOS="{goos}" GOARCH="{goarch}" CGO_ENABLED=0 '''
+        f'''env GOWORK=off {caddy_env_extra}GOOS="{goos}" GOARCH="{goarch}" CGO_ENABLED=0 '''
         f'''{xcaddy_exec} build '''
         f'''--with pkg.para.party/certdx/exec/caddytls=../exec/caddytls '''
         f'''--replace pkg.para.party/certdx=../ '''


### PR DESCRIPTION
## Summary

Task #27 — addresses @LDLDL's two questions about the nested-go.mod structure and xcaddy version resolution. Two related fixes:

### `go.work`

The repo's nested-module layout (root + 4 `exec/*` + `test/e2e`) made local development annoying: every submodule needed a `replace pkg.para.party/certdx => ../..` to resolve the parent locally, and IDEs had to be told about each sub-module. Adding a committed `go.work` at the root puts every module under one workspace so any `go build ./...` from any subdir resolves to local source — the replace directives stay only as a backstop for environments that don't load the workspace (notably xcaddy's temp build dir).

### `release/build.py` — `GOWORK=off` for xcaddy

xcaddy creates its temp build dir under `release/buildenv_*` — which is inside the repo, hence inside the new `go.work`. Without overriding, xcaddy's go subcommands enter workspace mode, find `./exec/caddytls` via the workspace, and silently bypass the `--replace pkg.para.party/certdx=...` flags we just passed (dev builds then fail with `cannot find module`). Setting `GOWORK=off` on the xcaddy invocation pins module mode so `--replace` is the single source of truth for what code ends up in the caddy binary.

### `docs/caddytls.md`

- Local-dev xcaddy invocation now spelled out with the required `--replace pkg.para.party/certdx=./` (was the silent failure mode).
- `go version -m <binary> | grep certdx` recipe to verify the `=> /local/path (devel)` lines, so a developer can prove their local code is in the binary even when the recorded version still reads `vX.Y.Z` from the latest registry tag.

### `CONTEXT.md`

New \"Repository layout\" section explaining:
- The 6-module nested layout and why each binary/plugin has its own go.mod (heavy per-binary deps stay isolated).
- That `go.work` is the local-dev source of truth and the submodule `replace` directives are only the backstop.
- That xcaddy does not honor `go.work` and needs explicit `--replace` for local builds.

## Out of scope (followup)

The lockstep tag recipe for releases (root tag + caddytls submodule tag must move together; bump caddytls's `require pkg.para.party/certdx vX.Y.Z` before tagging) — happy to add a `docs/release.md` in a follow-up if you want, but it's a process doc, not a code change.

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `go test -race -count=1 -tags=e2e ./test/e2e/...` — green (~253s)
- [x] `python3 release/build.py --dev` produces caddy binary; `go version -m ./caddy | grep certdx` shows both replaces in effect with `(devel)` markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)