### PR TITLE
fix: close and drain HTTP response body

### DIFF
--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
+	"io"
+	
 	"pkg.para.party/certdx/pkg/api"
 	"pkg.para.party/certdx/pkg/config"
 )
@@ -87,7 +88,10 @@ func (c *CertDXHttpClient) GetCertCtx(ctx context.Context, domains []string) (*a
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != 200 {
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, fmt.Errorf("POST '%s' status: %s", c.Server.Url, resp.Status)
 	}
 


### PR DESCRIPTION
Ensure GetCertCtx closes the response body on all successful HTTP request paths, and drains non-200 responses to allow connection reuse.