### PR TITLE
feat: build deb and rpm packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Install xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
       - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
         working-directory: release
         run: python3 build.py ${{ matrix.goos }} ${{ matrix.goarch }}
@@ -54,6 +57,8 @@ jobs:
           path: |
             release/*.zip
             release/*.tar.gz
+            release/*.deb
+            release/*.rpm
           if-no-files-found: error
           retention-days: 1
 
@@ -75,5 +80,7 @@ jobs:
           files: |
             release/*.zip
             release/*.tar.gz
+            release/*.deb
+            release/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 
 # Release files
 release/certdx_*
+release/certdx-*
 release/caddy_certdx_*
 /tools
 /server

--- a/docs/breaking-changes-v0.6.0.md
+++ b/docs/breaking-changes-v0.6.0.md
@@ -240,8 +240,8 @@ file.
   `--log /tmp/certdx-{server,client}.log`.
 - `certdx-{server,client}-fhs.service` — **FHS flavor** for deb/rpm:
   `ExecStart=/usr/bin/certdx_server --conf /etc/certdx/server.toml`,
-  runs as the `certdx` system user, `StateDirectory=certdx`, journald
-  logging, `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`,
+  runs as root, `StateDirectory=certdx`, journald logging,
+  `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`,
   `PrivateTmp` hardening. `/etc/certdx/mtls/` is read-only at runtime
   (the server only reads its bundle; tools create it pre-install).
 
@@ -277,9 +277,8 @@ silently writing `cache.json` in cwd.
 7. **If you parse PEM from `make-*` stdout**, switch to reading the
    bundle file the tool prints.
 8. **If you package via `.deb` / `.rpm`**, install to `/usr/bin/`, use
-   the `*-fhs.service` units, create the `certdx` system user, and
-   place mtls bundles under `/etc/certdx/mtls/` (config root) — not
-   `/var/lib/certdx/`.
+   the `*-fhs.service` units, and place mtls bundles under
+   `/etc/certdx/mtls/` (config root) — not `/var/lib/certdx/`.
 9. **If you embed certdx as a library**, switch to `pkg/mtls`
    (`LoadServer` / `LoadClient`) and handle the new error returns from
    `paths.ServerCachePath`, `server.NewCertStore`, and

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -195,18 +195,51 @@ writes its log to `/tmp/certdx-server.log` via `--log`.
 
 ### FHS install (`.deb` / `.rpm`)
 
-If you install via a system package that drops the binary at
-`/usr/bin/certdx_server`, the binary runs in **FHS install mode**:
+Each release ships `.deb` and `.rpm` packages for `linux/amd64`,
+`linux/arm64` and `linux/armhf`. Install with the system package
+manager:
+
+```sh
+# Debian / Ubuntu
+sudo apt install ./certdx_<version>_amd64.deb
+
+# Fedora / RHEL / openSUSE
+sudo dnf install ./certdx-<version>-1.x86_64.rpm
+```
+
+When installed at `/usr/bin/certdx_server`, the binary runs in
+**FHS install mode**:
 
 | Resource | FHS path |
 | --- | --- |
-| Binary | `/usr/bin/certdx_server` |
-| Config | `/etc/certdx/server.toml` |
+| Binaries | `/usr/bin/certdx_{server,client,tools}` |
+| Config | `/etc/certdx/{server,client}.toml` (you create) |
+| Example configs | `/etc/certdx/{server,client}.toml.example` (minimal, shipped) |
+| Full reference configs | `/etc/certdx/{server,client}.toml.full.example` (every option, shipped) |
 | State (`mtls/`, `private/`, `cache.json`) | `/var/lib/certdx/` |
+| Systemd units | `/usr/lib/systemd/system/certdx-{server,client}.service` |
 
-Use the `*-fhs.service` units, which pass `--conf /etc/certdx/server.toml`
-and run as the `certdx` system user with systemd `StateDirectory=certdx`.
-`--conf` is always required — there is no implicit default.
+The package does not enable or start any service: copy the example
+config you need, edit it, then enable the unit:
+
+```sh
+sudo cp /etc/certdx/server.toml.example /etc/certdx/server.toml
+sudoedit /etc/certdx/server.toml
+sudo systemctl enable --now certdx-server
+```
+
+Services run as root. The `*-fhs.service` units pass
+`--conf /etc/certdx/{server,client}.toml`; `--conf` is always required
+and has no implicit default. State (`mtls/`, `private/`, `cache.json`)
+is created under `/var/lib/certdx/` on demand via systemd's
+`StateDirectory=certdx`.
+
+Uninstall (`apt remove`, `apt purge`, `rpm -e`, `dnf remove`) stops
+the services and removes the shipped files. Your hand-written
+`/etc/certdx/*.toml` and the entire `/var/lib/certdx/` (mTLS material,
+ACME account keys, cert cache) are preserved — they may contain
+irreplaceable secrets and must be removed manually if you want a
+clean wipe.
 
 ### Overriding state location
 

--- a/release/build.py
+++ b/release/build.py
@@ -36,6 +36,7 @@ import datetime
 import os
 from pathlib import Path
 import shutil
+import string
 import subprocess
 import sys
 
@@ -66,6 +67,14 @@ EXECS = [
     ('tools',  'exec/tools'),
 ]
 
+# GOARCH -> (nfpm arch token, deb filename arch, rpm filename arch).
+# nfpm v2 accepts amd64/arm64 directly; arm7 -> debian armhf / rpm armv7hl.
+NFPM_ARCH_MAP = {
+    'amd64': ('amd64', 'amd64',  'x86_64'),
+    'arm64': ('arm64', 'arm64',  'aarch64'),
+    'arm':   ('arm7',  'armhf',  'armv7hl'),
+}
+
 
 def host_target() -> tuple[str, str]:
     goos = subprocess.run(
@@ -89,6 +98,38 @@ def find_xcaddy() -> Path:
              "(`go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest`).")
 
 
+def find_nfpm() -> Path:
+    nfpm = shutil.which("nfpm")
+    if nfpm:
+        return Path(nfpm)
+    fallback = Path.home() / "go" / "bin" / "nfpm"
+    if fallback.is_file():
+        return fallback
+    sys.exit("Error: nfpm is not installed. Install it before running build.py "
+             "(`go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest`).")
+
+
+def nfpm_version(build_tag: str) -> str:
+    """Convert `git describe` output to a deb/rpm-friendly version.
+
+    Mapping:
+      v1.2.3                            -> 1.2.3
+      v1.2.3-dirty                      -> 1.2.3~dirty
+      v1.2.3-5-g<sha>[-dirty]           -> 1.2.3~5.g<sha>[.dirty]
+      <sha>[-dirty] (no reachable tag)  -> 0.0.0~<sha>[.dirty]
+
+    The `~` separator makes prerelease/dirty versions sort lower than
+    the bare tag in both deb and rpm version comparison rules.
+    """
+    if build_tag.startswith('v'):
+        v = build_tag[1:]
+        if '-' in v:
+            tag, rest = v.split('-', 1)
+            return f'{tag}~{rest.replace("-", ".")}'
+        return v
+    return f'0.0.0~{build_tag.replace("-", ".")}'
+
+
 def purge_artifacts(release_path: Path, goos: str, goarch: str) -> None:
     """Remove prior build artifacts for this target."""
     names = [
@@ -103,6 +144,14 @@ def purge_artifacts(release_path: Path, goos: str, goarch: str) -> None:
             f = release_path / f'{name}{ext}'
             if f.exists():
                 f.unlink()
+    # deb/rpm filenames use packager-specific arch tokens that differ
+    # from goarch (arm -> armhf / armv7hl), so iterate explicitly.
+    if goos == 'linux' and goarch in NFPM_ARCH_MAP:
+        _, deb_arch, rpm_arch = NFPM_ARCH_MAP[goarch]
+        for f in release_path.glob(f'certdx_*_{deb_arch}.deb'):
+            f.unlink()
+        for f in release_path.glob(f'certdx-*.{rpm_arch}.rpm'):
+            f.unlink()
 
 
 def copy_release_files(repo_root: Path, output_dir: Path,
@@ -126,11 +175,15 @@ def build_certdx(repo_root: Path, output_dir: Path,
     # final binaries.
     strip_flags = '' if dev_mode else '-s -w '
 
+    # Pin GOARM=7 so 32-bit ARM tarballs and the armhf deb/rpm ship the
+    # same hard-float ELF.
+    goarm_env = 'GOARM="7" ' if goarch == 'arm' else ''
+
     for exec_name, source in EXECS:
         ext = '.exe' if goos == 'windows' else ''
         subprocess.run(
             f'''cd {repo_root / source} && '''
-            f'''env GOOS="{goos}" GOARCH="{goarch}" CGO_ENABLED=0 '''
+            f'''env GOOS="{goos}" GOARCH="{goarch}" {goarm_env}CGO_ENABLED=0 '''
             f'''go build -ldflags="{strip_flags}'''
             f'''-X main.buildTag={build_tag} -X 'main.buildDate={build_time}'" '''
             f'''-o {output_dir}/certdx_{exec_name}{ext}''',
@@ -152,6 +205,8 @@ def build_caddy(repo_root: Path, output_dir: Path,
         'GOARCH': goarch,
         'CGO_ENABLED': '0',
     }
+    if goarch == 'arm':
+        env['GOARM'] = '7'
 
     cmd = [str(xcaddy_exec), 'build',
            '--output', f'{output_dir}/caddy{ext}']
@@ -172,6 +227,42 @@ def build_caddy(repo_root: Path, output_dir: Path,
 
     if not dev_mode:
         copy_release_files(repo_root, output_dir, CADDY_COPY)
+
+
+def package_deb_rpm(repo_root: Path, release_path: Path,
+                    goarch: str, build_tag: str,
+                    nfpm_exec: Path) -> None:
+    """Produce .deb and .rpm for the staged linux/<goarch> build.
+
+    nfpm v2 does not env-var-substitute `contents.src` paths, so we
+    render `release/nfpm.yaml` ourselves with string.Template before
+    invoking nfpm. The rendered config goes to a per-arch sibling file
+    so concurrent matrix builds don't race on a shared name. Reads
+    binaries from release/certdx_linux_<goarch>/ and assets from the
+    repo root via paths in the YAML; must run before
+    package_artifacts(), which deletes the staging directory.
+    """
+    arch, _, _ = NFPM_ARCH_MAP[goarch]
+    template_path = release_path / 'nfpm.yaml'
+    rendered = string.Template(template_path.read_text()).substitute(
+        VERSION=nfpm_version(build_tag),
+        ARCH=arch,
+        GOARCH=goarch,
+    )
+    rendered_path = release_path / f'.nfpm-{goarch}.yaml'
+    rendered_path.write_text(rendered)
+    try:
+        for packager in ('deb', 'rpm'):
+            subprocess.run(
+                [str(nfpm_exec), 'pkg',
+                 '--packager', packager,
+                 '--config', str(rendered_path),
+                 '--target', str(release_path)],
+                cwd=str(repo_root),
+                check=True,
+            )
+    finally:
+        rendered_path.unlink()
 
 
 def package_artifacts(output_dir: Path, output_dir_caddy: Path,
@@ -233,6 +324,12 @@ def main() -> None:
         print(f"Dev build ready at {output_dir.relative_to(repo_root)}/"
               f" and {output_dir_caddy.relative_to(repo_root)}/")
         return
+
+    # Build .deb/.rpm before tarballing — package_artifacts deletes
+    # the staging dir that nfpm reads binaries from.
+    if goos == 'linux' and goarch in NFPM_ARCH_MAP:
+        nfpm_exec = find_nfpm()
+        package_deb_rpm(repo_root, release_path, goarch, build_tag, nfpm_exec)
 
     package_artifacts(output_dir, output_dir_caddy, goos)
 

--- a/release/nfpm.yaml
+++ b/release/nfpm.yaml
@@ -1,0 +1,100 @@
+# nfpm configuration for certdx (.deb / .rpm).
+#
+# This file is a template. release/build.py renders the placeholders
+# below via Python's string.Template before invoking nfpm, because
+# nfpm v2 does not env-var-substitute contents.src paths.
+#
+#   VERSION   debian/rpm-policy-friendly version string (no leading 'v')
+#   ARCH      nfpm arch token (amd64, arm64, arm7)
+#   GOARCH    Go GOARCH value (amd64, arm64, arm) - used to locate the
+#             staging directory release/certdx_linux_GOARCH/
+#
+# nfpm is invoked with cwd=repo_root, so all source paths below are
+# relative to the repository root.
+
+name: certdx
+arch: ${ARCH}
+platform: linux
+version: ${VERSION}
+section: net
+priority: optional
+maintainer: ParaParty <admin@para.party>
+vendor: ParaParty
+homepage: https://github.com/ParaParty/certdx
+license: MIT
+description: |
+  One ACME daemon for your whole fleet.
+  CertDX runs ACME in a single place, caches certificates, and hands
+  them out to as many services as you need over HTTPS or gRPC SDS.
+  This package installs certdx_server, certdx_client and certdx_tools
+  with FHS-flavor systemd units (config under /etc/certdx, state under
+  /var/lib/certdx).
+
+contents:
+  - src: release/certdx_linux_${GOARCH}/certdx_server
+    dst: /usr/bin/certdx_server
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  - src: release/certdx_linux_${GOARCH}/certdx_client
+    dst: /usr/bin/certdx_client
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  - src: release/certdx_linux_${GOARCH}/certdx_tools
+    dst: /usr/bin/certdx_tools
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  - src: systemd-service/certdx-server-fhs.service
+    dst: /usr/lib/systemd/system/certdx-server.service
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  - src: systemd-service/certdx-client-fhs.service
+    dst: /usr/lib/systemd/system/certdx-client.service
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  - src: config/server_config.toml
+    dst: /etc/certdx/server.toml.example
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  - src: config/client_config.toml
+    dst: /etc/certdx/client.toml.example
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  - src: config/server_config_full.toml
+    dst: /etc/certdx/server.toml.full.example
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  - src: config/client_config_full.toml
+    dst: /etc/certdx/client.toml.full.example
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+scripts:
+  postinstall: release/scripts/postinstall.sh
+  preremove:   release/scripts/preremove.sh
+  postremove:  release/scripts/postremove.sh

--- a/release/scripts/postinstall.sh
+++ b/release/scripts/postinstall.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# postinstall — runs after files are unpacked on install or upgrade.
+#
+# Reload systemd unit definitions and print next-step instructions.
+# Does NOT enable or start services: the FHS units require a
+# hand-written /etc/certdx/{server,client}.toml that the user must
+# create from the shipped *.example file.
+
+set -e
+
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+# Keep this message short: dnf5 truncates captured scriptlet output
+# at a fixed ~512-byte buffer, so anything longer is clipped mid-line.
+cat <<'EOF'
+
+certdx is installed. Config examples live in /etc/certdx.
+
+Setup guide: https://github.com/ParaParty/certdx/blob/main/docs/setup.md
+EOF
+
+exit 0

--- a/release/scripts/postremove.sh
+++ b/release/scripts/postremove.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# postremove — runs after files are removed on uninstall or upgrade.
+#
+# Reload systemd unit definitions. Intentionally does NOT delete
+# /etc/certdx/ or /var/lib/certdx/: those may contain CA private
+# keys, ACME account keys, and the cert cache that the user cannot
+# regenerate (Let's Encrypt rate limits). Operators who really want a
+# clean wipe should `rm -rf` them by hand.
+
+set -e
+
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+exit 0

--- a/release/scripts/preremove.sh
+++ b/release/scripts/preremove.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# preremove — runs before files are removed on uninstall or upgrade.
+#
+# Stop and disable the certdx services so an upgrade cleanly replaces
+# the running binaries. Best-effort: ignore failures (e.g. when the
+# package was installed without systemd, or the units were never
+# enabled).
+
+set -e
+
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl --no-reload disable --now \
+        certdx-server.service certdx-client.service >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/systemd-service/certdx-client-fhs.service
+++ b/systemd-service/certdx-client-fhs.service
@@ -5,8 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=certdx
-Group=certdx
 ExecStart=/usr/bin/certdx_client --conf /etc/certdx/client.toml
 Restart=always
 RestartSec=3

--- a/systemd-service/certdx-server-fhs.service
+++ b/systemd-service/certdx-server-fhs.service
@@ -5,8 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=certdx
-Group=certdx
 ExecStart=/usr/bin/certdx_server --conf /etc/certdx/server.toml
 Restart=always
 RestartSec=3


### PR DESCRIPTION
Add nfpm v2 packaging that produces a single `certdx` .deb and .rpm per linux arch, alongside the existing tarballs. The packages install all three binaries to /usr/bin, the FHS-flavor systemd units (renamed to drop the -fhs suffix) and example configs under /etc/certdx — exactly the layout pkg/paths already keys FHS install mode off.

packaging:
- release/nfpm.yaml: nfpm v2 contents/scripts template; rendered Python-side via string.Template before invoking nfpm because v2 doesn't env-substitute contents.src paths
- release/scripts/{postinstall,preremove,postremove}.sh: daemon-reload, best-effort disable --now on remove, and a post-install hint pointing at /etc/certdx/*.toml.example. Intentionally no user/group creation and no /etc/certdx or /var/lib/certdx deletion (state may hold CA private keys, ACME account keys, and the cert cache)

build.py:
- NFPM_ARCH_MAP for the three supported linux arches (amd64 -> amd64/x86_64, arm64 -> arm64/aarch64,
   arm   -> arm7  -> armhf/armv7hl)
- find_nfpm() and package_deb_rpm() helpers; called after
  build_certdx() and before package_artifacts() so nfpm can read the
  staging dir before it gets tarballed
- nfpm_version() converts `git describe` output to a debian/rpm-policy
  friendly form (v1.2.3-N-gSHA[-dirty] -> 1.2.3~N.gSHA[.dirty]) so
  prerelease/dirty builds sort below the bare tag
- pin GOARM=7 for goarch=arm in both build_certdx and build_caddy so
  the produced ELF matches the armhf/armv7hl package metadata
- purge_artifacts cleans stale .deb/.rpm for the target

systemd:
- drop User=certdx and Group=certdx from certdx-{server,client}-fhs.service; services now run as root. StateDirectory=certdx, ReadWritePaths and the rest of the hardening directives are unchanged

ci:
- install nfpm alongside xcaddy in .github/workflows/release.yaml
- include release/*.deb and release/*.rpm in both the per-target artifact upload and the softprops/action-gh-release files glob

docs:
- rewrite docs/setup.md "FHS install (.deb / .rpm)" with apt/dnf install snippets, the three-arch table, and the example-config flow
- drop the "create the certdx system user" mentions in docs/breaking-changes-v0.6.0.md (services now run as root)