### PR TITLE
feat: support custom nameservers and DNS timeout for DNS-01 propagation check

### DIFF
--- a/config/server_config_full.toml
+++ b/config/server_config_full.toml
@@ -34,6 +34,11 @@ client_x509_cert_url = "https://www.googleapis.com/robot/v1/metadata/x509/acme-u
 [DnsProvider]
 disableCompletePropagationRequirement = false
 
+# DNS propagation check settings
+# Use public DNS servers to check TXT record propagation
+# nameservers = ["8.8.8.8:53", "1.1.1.1:53"]
+# dnsTimeout = "30s"
+
 # cloudflare global api key and email
 type = "cloudflare"
 email = ""

--- a/pkg/acme/challenge.go
+++ b/pkg/acme/challenge.go
@@ -2,6 +2,7 @@ package acme
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/dns01"
@@ -22,7 +23,20 @@ func SetChallenger(legoCfg *lego.Config, instance *ACME, p *config.ServerConfig)
 		opt := make([]dns01.ChallengeOption, 0)
 
 		if p.DnsProvider.DisableCompletePropagationRequirement {
-			opt = append(opt, dns01.DisableCompletePropagationRequirement())
+			opt = append(opt, dns01.DisableAuthoritativeNssPropagationRequirement())
+		}
+
+		// 添加自定义 DNS 服务器
+		if len(p.DnsProvider.Nameservers) > 0 {
+			opt = append(opt, dns01.AddRecursiveNameservers(p.DnsProvider.Nameservers))
+		}
+
+		// 添加 DNS 超时
+		if p.DnsProvider.DNSTimeout != "" {
+			timeout, err := time.ParseDuration(p.DnsProvider.DNSTimeout)
+			if err == nil && timeout > 0 {
+				opt = append(opt, dns01.AddDNSTimeout(timeout))
+			}
 		}
 
 		if err := instance.Client.Challenge.SetDNS01Provider(clg, opt...); err != nil {

--- a/pkg/acme/challenge.go
+++ b/pkg/acme/challenge.go
@@ -34,9 +34,10 @@ func SetChallenger(legoCfg *lego.Config, instance *ACME, p *config.ServerConfig)
 		// 添加 DNS 超时
 		if p.DnsProvider.DNSTimeout != "" {
 			timeout, err := time.ParseDuration(p.DnsProvider.DNSTimeout)
-			if err == nil && timeout > 0 {
-				opt = append(opt, dns01.AddDNSTimeout(timeout))
+			if err != nil {
+				return fmt.Errorf("invalid dnsTimeout %q: %w", p.DnsProvider.DNSTimeout, err)
 			}
+			opt = append(opt, dns01.AddDNSTimeout(timeout))
 		}
 
 		if err := instance.Client.Challenge.SetDNS01Provider(clg, opt...); err != nil {

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -152,6 +152,15 @@ type DnsProvider struct {
 }
 
 func (p *DnsProvider) Validate() error {
+	if p.DNSTimeout != "" {
+		timeout, err := time.ParseDuration(p.DNSTimeout)
+		if err != nil {
+			return fmt.Errorf("DnsProvider: invalid dnsTimeout %q: %w", p.DNSTimeout, err)
+		}
+		if timeout <= 0 {
+			return fmt.Errorf("DnsProvider: dnsTimeout must be positive, got %q", p.DNSTimeout)
+		}
+	}
 	switch p.Type {
 	case DnsProviderTypeCloudflare:
 		if (p.Email == "" || p.APIKey == "") && (p.AuthToken == "" || p.ZoneToken == "") {

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -134,6 +134,10 @@ type DnsProvider struct {
 	Type                                  string `toml:"type" json:"type,omitempty"`
 	DisableCompletePropagationRequirement bool   `toml:"disableCompletePropagationRequirement" json:"disable_complete_propagation_requirement,omitempty"`
 
+	// DNS propagation check settings
+	Nameservers []string `toml:"nameservers" json:"nameservers,omitempty"`
+	DNSTimeout  string   `toml:"dnsTimeout" json:"dns_timeout,omitempty"`
+
 	// cloudflare global
 	Email  string `toml:"email" json:"email,omitempty"`
 	APIKey string `toml:"apiKey" json:"api_key,omitempty"`

--- a/pkg/config/server_test.go
+++ b/pkg/config/server_test.go
@@ -137,6 +137,30 @@ func TestDnsProviderValidateTencentCloudEmpty(t *testing.T) {
 	}
 }
 
+func TestDnsProviderValidateDNSTimeout(t *testing.T) {
+	base := DnsProvider{Type: DnsProviderTypeCloudflare, Email: "a@b.com", APIKey: "key"}
+
+	for _, valid := range []string{"", "30s", "1m30s"} {
+		p := base
+		p.DNSTimeout = valid
+		if err := p.Validate(); err != nil {
+			t.Fatalf("valid dnsTimeout %q: %v", valid, err)
+		}
+	}
+
+	for _, invalid := range []string{"30", "abc", "0s", "-5s"} {
+		p := base
+		p.DNSTimeout = invalid
+		err := p.Validate()
+		if err == nil {
+			t.Fatalf("expected error on dnsTimeout %q", invalid)
+		}
+		if !strings.Contains(err.Error(), "dnsTimeout") {
+			t.Fatalf("error wording drifted: %v", err)
+		}
+	}
+}
+
 func TestDnsProviderValidateUnknownType(t *testing.T) {
 	p := &DnsProvider{Type: "route53"}
 	err := p.Validate()


### PR DESCRIPTION
## Summary

- Add two optional `[DnsProvider]` config fields:
  - `nameservers` — recursive DNS servers (e.g. `["8.8.8.8:53", "1.1.1.1:53"]`) used to check TXT record propagation, useful when the local resolver has caching or pollution issues
  - `dnsTimeout` — timeout for DNS propagation queries (e.g. `"30s"`)
- Wire them into the DNS-01 challenge setup via lego's `dns01.AddRecursiveNameservers` / `dns01.AddDNSTimeout`
- Replace deprecated `dns01.DisableCompletePropagationRequirement` with `DisableAuthoritativeNssPropagationRequirement` (same behavior, renamed upstream)
- Document the new fields in `config/server_config_full.toml`

Both fields are optional; existing configs are unaffected.

## Testing

- `go build ./...` and `go vet` pass
- `go test ./pkg/acme/... ./pkg/config/...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)