### PR TITLE
fix: address 48 findings from full code-review (server / client / ACME / tools)

### DIFF
--- a/config/server_config.toml
+++ b/config/server_config.toml
@@ -20,5 +20,6 @@ secure = true
 # Domain of this server, server will issue a certification for itself
 # for https api. Make sure your acme server can issue this domain.
 names = ["certdxserver.example.com", "*.example.com"]
-# left empty for no token
+# Required with the default authMethod = "token". To serve without any
+# authentication, leave it empty and set allowAnonymous = true.
 token = "KFCCrazyThursdayVMe50"

--- a/config/server_config_full.toml
+++ b/config/server_config_full.toml
@@ -10,6 +10,10 @@ challengeType = "dns"
 # Certification will have a life time of certLifeTime + renewTimeLeft
 # If certLifeTime is passed, server will renew this certification
 # Server and client will check certification every renewTimeLeft/4
+# Both must be positive and renewTimeLeft must not be longer than certLifeTime.
+# Their sum is what is asked of the ACME provider: Google rejects anything over
+# the 90 days it can issue, Let's Encrypt ignores the request and the server
+# renews on the issued certificate's real expiry (logging a warning).
 certLifeTime = "168h"
 renewTimeLeft = "24h"
 
@@ -17,6 +21,11 @@ renewTimeLeft = "24h"
 allowedDomains = [
     "example.com",
 ]
+
+# Caps how many distinct cert packs the server will keep in its cache, so an
+# unauthenticated flood of domain sets can not grow it without bound.
+# 0 (the default) means unlimited.
+maxCacheEntries = 0
 
 # Google cloud credential, for registering google acme account
 [GoogleCloudCredential]
@@ -36,6 +45,7 @@ disableCompletePropagationRequirement = false
 
 # DNS propagation check settings
 # Use public DNS servers to check TXT record propagation
+# Each entry must be host[:port], port defaults to 53. No scheme, no URL.
 # nameservers = ["8.8.8.8:53", "1.1.1.1:53"]
 # dnsTimeout = "30s"
 
@@ -50,7 +60,7 @@ apiKey = ""
 # zoneToken = "XOoC9QinSF_LRBQwmAfKPKbqZyKeZH2vyOLZUKVw"
 
 # or you can use tencent cloud
-# type = "tencent"
+# type = "tencentcloud"
 # secretID = ""
 # SecretKey = ""
 
@@ -64,6 +74,16 @@ accessKeyId = "xxxxxxxxxx"
 accessKeySecret = "xxxxxxxx"
 sessionToken = ""
 url = "https://cos.ap-beijing.myqcloud.com"
+# Canned ACL sent with the challenge object.
+#   - leave this key out (the default): "public-read" is sent, which is what
+#     certdx <= v0.6.0 always did. Existing ACL-enabled buckets keep working.
+#   - acl = "": no ACL header is sent at all. Buckets created since Apr 2023
+#     have ACLs disabled by default and reject any x-amz-acl header, so this
+#     is the setting for them; make the challenge path publicly readable via
+#     the bucket policy instead.
+#   - any other canned ACL ("private", "bucket-owner-full-control", ...) is
+#     sent as-is.
+# acl = "public-read"
 
 # [MTLS] is required when authMethod = "mtls" or gRPCSDSServer is enabled.
 # pem is the path to the server PEM bundle (server cert + key + CA cert).
@@ -75,13 +95,19 @@ enabled = true
 listen = ":19198"
 apiPath = "/1145141919810"
 
+# "token" or "mtls", defaults to "token"
 authMethod = "token"
 secure = true
 # Domain of this server, server will issue a certification for itself
 # for https api. Make sure your acme server can issue this domain.
 names = ["certdxserver.example.com", "*.example.com"]
-# left empty for no token
+# Required when authMethod = "token". To serve without any authentication,
+# leave it empty and set allowAnonymous = true.
 token = "KFCCrazyThursdayVMe50"
+# allowAnonymous = false
+# authMethod = "token" with secure = false serves the token and the private
+# keys in cleartext, which logs a warning on startup. Set this to silence it.
+# allowInsecureToken = false
 
 # authMethod = "mtls"
 

--- a/docs/caddytls.md
+++ b/docs/caddytls.md
@@ -104,7 +104,7 @@ Top-level directives:
 | Directive | Notes |
 | --- | --- |
 | `url` | Full URL including the server's `apiPath`. |
-| `authMethod` | `token` (default) or `mtls`. |
+| `authMethod` | `token` (default) or `mtls`. Any other value fails `caddy adapt` instead of being silently ignored. |
 | `token` | Bearer token for `authMethod token`. |
 | `pem` | PEM bundle (client cert + key + CA cert) for `authMethod mtls`. |
 
@@ -126,6 +126,11 @@ https://example.com {
 ```
 
 `my-cert` must match a `certificate <id> { ... }` block in the global config.
+
+Certificate material is kept in Caddy's usage pool, so a config reload
+(`caddy reload`) keeps serving the certificates already fetched instead of
+falling back to a cold start while the new client re-fetches them. A full
+process restart still starts cold.
 
 ## Full example
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -90,8 +90,15 @@ reloadCommand = "systemctl reload nginx"
 ## Renewal cadence
 
 The client polls the server on the same cadence as the server's renewal
-check (`ACME.renewTimeLeft / 4`). When the server returns a newer
-certificate, the client overwrites both files and runs `reloadCommand`.
+check (`ACME.renewTimeLeft / 4`), floored at one minute so a server that
+reports a tiny or zero `renewTimeLeft` cannot turn the poller into a hot
+loop. A failed round does not wait that long: it retries after 15s and
+backs off up to 60s until the server answers again. When the server
+returns a newer certificate, the client overwrites both files and runs
+`reloadCommand`.
+
+`reloadCommand` is given 60 seconds to finish before it is killed, so a
+command that hangs cannot wedge the certificate handler.
 
 Writes are atomic via a temp-file-and-rename, so a downstream service
 reading the cert mid-update never observes a torn or partial file. The

--- a/docs/server.md
+++ b/docs/server.md
@@ -42,9 +42,16 @@ The configuration is a TOML file. Top-level sections:
 | `provider` | string | `"r3"` | One of `r3`, `r3test`, `google`, `googletest`. |
 | `retryCount` | int | `5` | Per-issuance retry count. |
 | `challengeType` | string | `"dns"` | `dns` or `http`. |
-| `certLifeTime` | duration string | `"168h"` | Lifetime of issued certificates the server requests/tracks. |
-| `renewTimeLeft` | duration string | `"24h"` | Renew when remaining lifetime drops below this. The renewal check runs every `renewTimeLeft / 4`. |
+| `certLifeTime` | duration string | `"168h"` | Lifetime of issued certificates the server requests/tracks. Must be positive. |
+| `renewTimeLeft` | duration string | `"24h"` | Renew when remaining lifetime drops below this. The renewal check runs every `renewTimeLeft / 4`. Must be positive and shorter than `certLifeTime`. |
 | `allowedDomains` | string list | *(required)* | Root domains the server is allowed to issue. Requests for domains outside this list are rejected. |
+| `maxCacheEntries` | int | `0` | Cap on the number of distinct cert packs the cache tracks. `0` means unlimited. |
+
+A certificate is requested to stay valid for `certLifeTime + renewTimeLeft`,
+so that sum is what the ACME provider has to be able to issue. Both Let's
+Encrypt and Google Trust Services cap at 90 days; a configuration whose sum
+exceeds that is rejected at startup rather than yielding certificates that
+expire long before the server thinks they do.
 
 Supported ACME providers:
 
@@ -73,11 +80,18 @@ block is in `config/server_config_full.toml`.
 | --- | --- | --- |
 | `type` | string | `cloudflare` or `tencentcloud`. |
 | `disableCompletePropagationRequirement` | bool | Skip the lego "wait for full propagation" step. |
+| `nameservers` | string list | Resolvers used for the DNS-01 propagation check, as `host` or `host:port`. URLs and entries with whitespace are rejected at startup. |
+| `dnsTimeout` | duration string | Per-query timeout for the propagation check. Must be positive. |
 | `email`, `apiKey` | string | Cloudflare global API key auth. |
 | `authToken`, `zoneToken` | string | Cloudflare scoped token auth (alternative to global). |
 | `secretID`, `secretKey` | string | Tencent Cloud credentials. |
 
 Exactly one credential set must be configured for the chosen `type`.
+
+With `disableCompletePropagationRequirement = true` the authoritative-server
+check is skipped, so the TXT record is instead verified on the resolvers in
+`nameservers` before the challenge is handed to the ACME server. Without
+`nameservers`, that mode does no verification at all — set both together.
 
 ### `[HttpProvider]` and `[HttpProvider.S3]`
 
@@ -100,6 +114,20 @@ sessionToken = ""
 url = "https://cos.ap-beijing.myqcloud.com"
 ```
 
+`acl` is optional and controls the canned ACL sent with the challenge object:
+
+- leave the key out (the default): `public-read` is sent, which is what certdx
+  has always done, so an existing ACL-enabled bucket keeps working after an
+  upgrade;
+- `acl = ""`: no canned-ACL header is sent at all. Buckets created since April
+  2023 have ACLs disabled by default and reject any `x-amz-acl` header, so this
+  is the setting for them — make the challenge path publicly readable with a
+  bucket policy instead;
+- any other AWS canned ACL (`private`, `public-read-write`,
+  `authenticated-read`, `aws-exec-read`, `bucket-owner-read`,
+  `bucket-owner-full-control`) is sent as-is; anything else is rejected at
+  startup.
+
 ### `[HttpServer]`
 
 The HTTPS endpoint that `certdx_client` and the Caddy plugin call into.
@@ -109,10 +137,21 @@ The HTTPS endpoint that `certdx_client` and the Caddy plugin call into.
 | `enabled` | bool | `false` | Enable the HTTP server. |
 | `listen` | string | `":10001"` | Listen address. |
 | `apiPath` | string | `"/"` | Base API path. A leading `/` is added automatically if missing. |
-| `authMethod` | string | `"token"` | `token` or `mtls`. |
+| `authMethod` | string | `"token"` | `token` or `mtls`. Any other value is rejected at startup. |
 | `secure` | bool | `false` | When `true`, the server obtains a certificate for itself via ACME and serves HTTPS. Required when running on the public internet. |
 | `names` | string list | `[]` | SANs for the self-issued server certificate. Required when `secure = true`. Must be issuable under `ACME.allowedDomains`. |
-| `token` | string | `""` | Shared bearer token (only with `authMethod = "token"`). Empty disables token auth. |
+| `token` | string | `""` | Shared bearer token (only with `authMethod = "token"`). Required unless `allowAnonymous = true`. |
+| `allowAnonymous` | bool | `false` | Serve without any authentication. Only then is an empty `token` accepted. |
+| `allowInsecureToken` | bool | `false` | Silence the startup warning about serving the token and private keys over plain HTTP (`secure = false`). |
+
+An enabled token-auth server with an empty `token` used to serve every caller
+anonymously by accident. That is now an error: to run without authentication,
+say so with `allowAnonymous = true`.
+
+With `secure = false` the bearer token and the issued private keys travel in
+cleartext, so the server logs a warning on every start. Run it only on a
+trusted network (or behind a TLS terminator), and set `allowInsecureToken =
+true` to acknowledge the trade-off and silence the warning.
 
 When `authMethod = "mtls"`, the server loads its mTLS material from the
 PEM bundle specified in `[MTLS].pem`. The bundle contains the server cert,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -137,6 +137,9 @@ Keep `ca.pem` only on the server host (it contains the CA private key).
 The name `ca` is reserved; `make-client` and `make-server` reject it so
 a typo cannot silently overwrite the CA.
 
+Entity bundles are valid for two years and the CA for ten (override with
+`--valid-for`), so schedule a re-issue before they expire.
+
 See [tools.md](tools.md) for the full flag set.
 
 ## 4. Server-side install

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -48,6 +48,12 @@ than dumping the PEM blocks to stdout.
 `make-client` and `make-server` reserve the name `ca` (case-insensitive,
 trimmed) so a typo cannot silently overwrite the CA bundle.
 
+Issued entity certificates are valid for two years and the CA for ten,
+rather than effectively forever, so a leaked mTLS key eventually stops
+being useful. Plan on re-running `make-server` / `make-client` before the
+bundles expire, or pass `--valid-for` to pick a different period.
+Certificates issued by an earlier version are unaffected.
+
 ---
 
 ## `show-certs`
@@ -82,7 +88,13 @@ Cloud credentials).
 | `-k`, `--kid` | yes | EAB key id. |
 | `-m`, `--hmac` | yes | EAB B64 HMAC. |
 | `-t`, `--test-account` | | Register against the Google staging endpoint (`googletest`). |
+| `-f`, `--force` | | Overwrite an existing account key for this `(email, provider)` pair. |
 | `-h`, `--help` | | Print help. |
+
+Without `--force` the command refuses to run when
+`private/<email>_<provider>.key` already exists: re-registering mints a new
+account key, and the old one — the only way to manage the certificates
+already issued under it — would be gone.
 
 Example:
 
@@ -104,6 +116,7 @@ bundle with `0600`.
 | --- | --- | --- |
 | `-o`, `--organization` | `CertDX Private` | Subject `O`. |
 | `-c`, `--common-name` | `CertDX Private Certificate Authority` | Subject `CN`. |
+| `--valid-for` | `87600h` (10 years) | Certificate validity period. |
 | `--data-dir` | *(install-mode default)* | Parent directory of `mtls/`. Env: `CERTDX_DATA_DIR`. |
 
 ## `make-server`
@@ -117,6 +130,7 @@ server key + CA cert) signed by the CA. Run after `make-ca`.
 | `-d`, `--dns-names` | yes | Comma-separated SANs. Must include every name a client will dial. |
 | `-o`, `--organization` | | Subject `O`. Default `CertDX Private`. |
 | `-c`, `--common-name` | | Subject `CN`. Default `CertDX Secret Discovery Service`. |
+| `--valid-for` | | Certificate validity period. Default `17520h` (2 years). |
 | `--data-dir` | | Parent directory of `mtls/`. Env: `CERTDX_DATA_DIR`. |
 
 Example:
@@ -140,6 +154,7 @@ silently overwrite the CA bundle.
 | `-d`, `--dns-names` | | Optional SANs. |
 | `-o`, `--organization` | | Subject `O`. |
 | `-c`, `--common-name` | | Subject `CN`. Default `CertDX Client: <name>`. |
+| `--valid-for` | | Certificate validity period. Default `17520h` (2 years). |
 | `--data-dir` | | Parent directory of `mtls/`. Env: `CERTDX_DATA_DIR`. |
 
 Example:

--- a/exec/caddytls/caddyfile.go
+++ b/exec/caddytls/caddyfile.go
@@ -33,10 +33,15 @@ func init() {
 	httpcaddyfile.RegisterGlobalOption(dirCertDX, parseCertDXGlobalOptions)
 }
 
+// expectArg1 consumes the rest of the line and returns its single
+// argument. The directive name has to be captured before RemainingArgs
+// advances the dispenser, otherwise the error names the last argument
+// value instead of the directive it belongs to.
 func expectArg1(d *caddyfile.Dispenser) (string, error) {
+	directive := d.Val()
 	args := d.RemainingArgs()
 	if len(args) != 1 {
-		return "", d.Errf("expected 1 argument for %s, got %d", d.Val(), len(args))
+		return "", d.Errf("expected 1 argument for %s, got %d", directive, len(args))
 	}
 	return args[0], nil
 }
@@ -141,6 +146,15 @@ func (c *CertDXCaddyDaemon) unmarshalHttpServerBlock(s *config.ClientHttpServer,
 			case dirURL:
 				s.Url = v
 			case dirAuthMethod:
+				// An unrecognised value would leave auth disabled, so a
+				// typo such as "mTLS" has to fail the adapt, not the
+				// first request.
+				switch v {
+				case config.HTTP_AUTH_TOKEN, config.HTTP_AUTH_MTLS:
+				default:
+					return d.Errf("invalid %s %q, expected %q or %q",
+						dirAuthMethod, v, config.HTTP_AUTH_TOKEN, config.HTTP_AUTH_MTLS)
+				}
 				s.AuthMethod = v
 			case dirToken:
 				s.Token = v

--- a/exec/caddytls/caddytls.go
+++ b/exec/caddytls/caddytls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -23,6 +24,7 @@ type CertDXTls struct {
 	certDXApp *CertDXCaddyDaemon
 	CertId    string `json:"cert_id"`
 	certHash  domain.Key
+	domains   []string
 }
 
 func (CertDXTls) CaddyModule() caddy.ModuleInfo {
@@ -53,12 +55,60 @@ func (certdx *CertDXTls) Validate() error {
 	if !ok {
 		return fmt.Errorf("no certificate definition for cert-id %q", certdx.CertId)
 	}
+	certdx.domains = domains
 	certdx.certHash = domain.AsKey(domains)
 	return nil
 }
 
-func (certdx CertDXTls) GetCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	return certdx.certDXApp.GetCertificate(ctx, certdx.certHash)
+// certPackCovers reports whether the cert pack's domain list contains a
+// name that a TLS peer would accept for serverName: an exact match, or a
+// wildcard entry matching exactly one label below its base.
+//
+// This is deliberately stricter than domain.CertCovers, which also treats
+// a literal entry as covering its subdomains — right for the server's
+// allow-list gate and the Kubernetes updater, wrong here, where a
+// certificate for "example.com" does not serve "foo.example.com".
+func certPackCovers(domains []string, serverName string) bool {
+	name := normalizeName(serverName)
+	if name == "" {
+		return false
+	}
+	for _, entry := range domains {
+		e := normalizeName(entry)
+		if name == e {
+			return true
+		}
+		base, isWildcard := strings.CutPrefix(e, "*.")
+		if !isWildcard {
+			continue
+		}
+		if label, ok := strings.CutSuffix(name, "."+base); ok && label != "" && !strings.Contains(label, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeName(name string) string {
+	return strings.ToLower(strings.TrimSuffix(name, "."))
+}
+
+// GetCertificate serves the cert pack bound to this manager's cert-id.
+// certmagic consults every configured manager in turn, so a ServerName
+// this pack does not cover must come back as (nil, nil): an error would
+// be recorded by certmagic's single-flight and fail handshakes another
+// manager could have served. A client that sent no SNI at all gets the
+// pack's certificate, as before.
+func (certdx *CertDXTls) GetCertificate(ctx context.Context, hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if hello != nil && hello.ServerName != "" && !certPackCovers(certdx.domains, hello.ServerName) {
+		return nil, nil
+	}
+
+	cert, err := certdx.certDXApp.GetCertificate(ctx, certdx.certHash)
+	if err != nil {
+		return nil, fmt.Errorf("certdx certificate %q: %w", certdx.CertId, err)
+	}
+	return cert, nil
 }
 
 // UnmarshalCaddyfile deserializes Caddyfile tokens.

--- a/exec/caddytls/caddytls_test.go
+++ b/exec/caddytls/caddytls_test.go
@@ -1,0 +1,320 @@
+package caddytls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+
+	"pkg.para.party/certdx/pkg/config"
+	"pkg.para.party/certdx/pkg/domain"
+)
+
+// makeKeyPair mints a throwaway self-signed leaf so the tests can
+// exercise the parse path without touching the network or an ACME server.
+func makeKeyPair(t *testing.T, cn string) (fullchain, key []byte) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		DNSNames:     []string{cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDer, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDer})
+}
+
+func TestCertPackCovers(t *testing.T) {
+	domains := []string{"example.com", "*.wild.com"}
+
+	cases := []struct {
+		name string
+		sni  string
+		want bool
+	}{
+		{"exact", "example.com", true},
+		{"exact case insensitive", "EXAMPLE.COM", true},
+		{"exact trailing dot", "example.com.", true},
+		{"literal entry does not cover subdomain", "foo.example.com", false},
+		{"wildcard one label", "foo.wild.com", true},
+		{"wildcard two labels", "foo.bar.wild.com", false},
+		{"wildcard base", "wild.com", false},
+		{"wildcard literal", "*.wild.com", true},
+		{"unrelated", "other.net", false},
+		{"empty", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := certPackCovers(domains, c.sni); got != c.want {
+				t.Fatalf("certPackCovers(%q) = %v, want %v", c.sni, got, c.want)
+			}
+		})
+	}
+}
+
+func TestGetCertificateSNIMismatchFallsThrough(t *testing.T) {
+	fullchain, key := makeKeyPair(t, "example.com")
+
+	domains := []string{"example.com"}
+	certHash := domain.AsKey(domains)
+	shared := &sharedCert{}
+	if err := shared.store(fullchain, key); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	app := &CertDXCaddyDaemon{certs: map[domain.Key]*sharedCert{certHash: shared}}
+	m := &CertDXTls{CertId: "web", certDXApp: app, certHash: certHash, domains: domains}
+
+	got, err := m.GetCertificate(t.Context(), &tls.ClientHelloInfo{ServerName: "example.com"})
+	if err != nil || got == nil {
+		t.Fatalf("matching SNI: got (%v, %v), want a certificate", got, err)
+	}
+
+	// A name this pack does not cover must not be an error: certmagic
+	// caches the failure and would poison unrelated handshakes.
+	got, err = m.GetCertificate(t.Context(), &tls.ClientHelloInfo{ServerName: "other.net"})
+	if got != nil || err != nil {
+		t.Fatalf("non-matching SNI: got (%v, %v), want (nil, nil)", got, err)
+	}
+
+	// No SNI at all keeps the previous behaviour of serving the pack.
+	got, err = m.GetCertificate(t.Context(), &tls.ClientHelloInfo{})
+	if err != nil || got == nil {
+		t.Fatalf("empty SNI: got (%v, %v), want a certificate", got, err)
+	}
+}
+
+func TestGetCertificatePropagatesParseError(t *testing.T) {
+	domains := []string{"example.com"}
+	certHash := domain.AsKey(domains)
+	shared := &sharedCert{}
+	if err := shared.store([]byte("not a pem"), []byte("neither is this")); err == nil {
+		t.Fatal("store: expected an error for garbage material")
+	}
+
+	app := &CertDXCaddyDaemon{certs: map[domain.Key]*sharedCert{certHash: shared}}
+	m := &CertDXTls{CertId: "web", certDXApp: app, certHash: certHash, domains: domains}
+
+	_, err := m.GetCertificate(t.Context(), &tls.ClientHelloInfo{ServerName: "example.com"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "web") || strings.Contains(err.Error(), "no certificate found") {
+		t.Fatalf("error %q swallows the cause", err)
+	}
+}
+
+func TestSharedCertKeepsLastGoodMaterial(t *testing.T) {
+	fullchain, key := makeKeyPair(t, "example.com")
+
+	shared := &sharedCert{}
+	if _, err := shared.certificate(); err == nil {
+		t.Fatal("expected an error before any material is stored")
+	}
+	if err := shared.store(fullchain, key); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := shared.store(fullchain, []byte("broken")); err == nil {
+		t.Fatal("expected an error for a broken key")
+	}
+	if cert, err := shared.certificate(); err != nil || cert == nil {
+		t.Fatalf("certificate() = (%v, %v), want the last good keypair", cert, err)
+	}
+}
+
+// TestSharedCertsSurviveReload walks the reference dance Caddy performs on
+// a config reload: the new app provisions (and so acquires) before the old
+// one is cleaned up, which is what keeps the material alive.
+func TestSharedCertsSurviveReload(t *testing.T) {
+	fullchain, key := makeKeyPair(t, "example.com")
+	certHash := domain.AsKey([]string{"example.com"})
+
+	old := &CertDXCaddyDaemon{}
+	shared, err := old.acquireSharedCert(certHash)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = old.Cleanup() })
+	if err := shared.store(fullchain, key); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	fresh := &CertDXCaddyDaemon{}
+	reloaded, err := fresh.acquireSharedCert(certHash)
+	if err != nil {
+		t.Fatalf("acquire after reload: %v", err)
+	}
+	t.Cleanup(func() { _ = fresh.Cleanup() })
+
+	if err := old.Cleanup(); err != nil {
+		t.Fatalf("cleanup old: %v", err)
+	}
+	if cert, err := reloaded.certificate(); err != nil || cert == nil {
+		t.Fatalf("after reload: (%v, %v), want the carried-over keypair", cert, err)
+	}
+
+	// Once the last config referencing it goes away the entry is dropped.
+	if err := fresh.Cleanup(); err != nil {
+		t.Fatalf("cleanup fresh: %v", err)
+	}
+	if _, ok := sharedCerts.References(certHash); ok {
+		t.Fatal("shared cert entry outlived its last reference")
+	}
+}
+
+func TestSetDefaultConfigFillsOnlyUnsetFields(t *testing.T) {
+	var c CertDXCaddyConfig
+	c.Mode = config.CLIENT_MODE_GRPC
+	c.Http.MainServer.AuthMethod = config.HTTP_AUTH_MTLS
+
+	c.SetDefaultConfig()
+
+	if c.RetryCount != defaultRetryCount {
+		t.Fatalf("RetryCount = %d, want %d", c.RetryCount, defaultRetryCount)
+	}
+	if c.ReconnectInterval != defaultReconnectInterval {
+		t.Fatalf("ReconnectInterval = %q, want %q", c.ReconnectInterval, defaultReconnectInterval)
+	}
+	if c.Mode != config.CLIENT_MODE_GRPC {
+		t.Fatalf("Mode = %q, want it left alone", c.Mode)
+	}
+	if c.Http.MainServer.AuthMethod != config.HTTP_AUTH_MTLS {
+		t.Fatalf("MainServer.AuthMethod = %q, want it left alone", c.Http.MainServer.AuthMethod)
+	}
+	// A native-JSON config that omits authMethod must not end up sending
+	// unauthenticated requests.
+	if c.Http.StandbyServer.AuthMethod != config.HTTP_AUTH_TOKEN {
+		t.Fatalf("StandbyServer.AuthMethod = %q, want %q",
+			c.Http.StandbyServer.AuthMethod, config.HTTP_AUTH_TOKEN)
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	pem := filepath.Join(t.TempDir(), "bundle.pem")
+	if err := os.WriteFile(pem, []byte("bundle"), 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	newHTTP := func(mutate func(*CertDXCaddyConfig)) *CertDXCaddyConfig {
+		c := &CertDXCaddyConfig{}
+		c.SetDefaultConfig()
+		c.Http.MainServer.Url = "https://certdx.example.com"
+		c.Http.MainServer.Token = "secret"
+		if mutate != nil {
+			mutate(c)
+		}
+		return c
+	}
+
+	cases := []struct {
+		name    string
+		cfg     *CertDXCaddyConfig
+		wantErr bool
+	}{
+		{"http token", newHTTP(nil), false},
+		{"http missing url", newHTTP(func(c *CertDXCaddyConfig) { c.Http.MainServer.Url = "" }), true},
+		{"http bad auth method", newHTTP(func(c *CertDXCaddyConfig) { c.Http.MainServer.AuthMethod = "mTLS" }), true},
+		{"http mtls missing pem", newHTTP(func(c *CertDXCaddyConfig) {
+			c.Http.MainServer.AuthMethod = config.HTTP_AUTH_MTLS
+			c.Http.MainServer.PEM = filepath.Join(t.TempDir(), "absent.pem")
+		}), true},
+		{"http mtls present pem", newHTTP(func(c *CertDXCaddyConfig) {
+			c.Http.MainServer.AuthMethod = config.HTTP_AUTH_MTLS
+			c.Http.MainServer.PEM = pem
+		}), false},
+		{"http standby bad pem", newHTTP(func(c *CertDXCaddyConfig) {
+			c.Http.StandbyServer.Url = "https://standby.example.com"
+			c.Http.StandbyServer.AuthMethod = config.HTTP_AUTH_MTLS
+			c.Http.StandbyServer.PEM = filepath.Join(t.TempDir(), "absent.pem")
+		}), true},
+		{"grpc missing pem", newHTTP(func(c *CertDXCaddyConfig) {
+			c.Mode = config.CLIENT_MODE_GRPC
+			c.GRPC.MainServer.Server = "certdx.example.com:1443"
+			c.GRPC.MainServer.PEM = filepath.Join(t.TempDir(), "absent.pem")
+		}), true},
+		{"grpc ok", newHTTP(func(c *CertDXCaddyConfig) {
+			c.Mode = config.CLIENT_MODE_GRPC
+			c.GRPC.MainServer.Server = "certdx.example.com:1443"
+			c.GRPC.MainServer.PEM = pem
+		}), false},
+		{"unknown mode", newHTTP(func(c *CertDXCaddyConfig) { c.Mode = "quic" }), true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.validateConfig()
+			if (err != nil) != c.wantErr {
+				t.Fatalf("validateConfig() = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestUnmarshalHttpServerBlockRejectsUnknownAuthMethod(t *testing.T) {
+	c := MakeCertDXCaddyDaemon()
+	d := caddyfile.NewTestDispenser(`main_server {
+	url https://certdx.example.com
+	authMethod mTLS
+	token secret
+}`)
+
+	err := c.unmarshalHttpServerBlock(&c.Http.MainServer, d)
+	if err == nil {
+		t.Fatal("expected a typo'd auth method to fail the adapt")
+	}
+	if !strings.Contains(err.Error(), dirAuthMethod) {
+		t.Fatalf("error %q does not mention %s", err, dirAuthMethod)
+	}
+}
+
+func TestUnmarshalHttpServerBlockAcceptsKnownAuthMethods(t *testing.T) {
+	for _, method := range []string{config.HTTP_AUTH_TOKEN, config.HTTP_AUTH_MTLS} {
+		c := MakeCertDXCaddyDaemon()
+		d := caddyfile.NewTestDispenser("main_server {\n\tauthMethod " + method + "\n}")
+		if err := c.unmarshalHttpServerBlock(&c.Http.MainServer, d); err != nil {
+			t.Fatalf("authMethod %q: %v", method, err)
+		}
+		if c.Http.MainServer.AuthMethod != method {
+			t.Fatalf("AuthMethod = %q, want %q", c.Http.MainServer.AuthMethod, method)
+		}
+	}
+}
+
+func TestExpectArg1NamesTheDirective(t *testing.T) {
+	d := caddyfile.NewTestDispenser("retry_count 3 4\n")
+	d.Next()
+
+	_, err := expectArg1(d)
+	if err == nil {
+		t.Fatal("expected an error for two arguments")
+	}
+	if !strings.Contains(err.Error(), dirRetryCount) {
+		t.Fatalf("error %q names an argument instead of the directive", err)
+	}
+}

--- a/exec/caddytls/certdx.go
+++ b/exec/caddytls/certdx.go
@@ -3,6 +3,7 @@ package caddytls
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -18,6 +19,80 @@ import (
 
 func init() {
 	caddy.RegisterModule(&CertDXCaddyDaemon{})
+}
+
+// Defaults applied to every field the user left unset. They mirror
+// config.ClientConfig.SetDefault so the plugin and the standalone client
+// behave the same.
+const (
+	defaultRetryCount        = 5
+	defaultReconnectInterval = "10m"
+)
+
+// errNoCertYet is returned while a cert pack has never produced usable
+// material — neither carried over from a previous config nor fetched by
+// the running daemon.
+var errNoCertYet = errors.New("no certificate material available yet")
+
+// sharedCerts keeps the material of a cert pack alive across Caddy config
+// reloads, keyed by domain.Key. Provision takes one reference per
+// certificate definition and Cleanup releases it, so the entry outlives
+// the app instance that created it: Caddy provisions the new config
+// before stopping the old one. Without it every reload would start from
+// an empty cache and blackout TLS until the first poll round lands, since
+// certmagic does not cache manager-provided certificates.
+var sharedCerts = caddy.NewUsagePool()
+
+// sharedCert is one entry of sharedCerts: the parsed keypair for a single
+// cert pack. The keypair is parsed once per renewal rather than per
+// handshake, which is also what keeps the real parse error around to hand
+// back to callers.
+type sharedCert struct {
+	mu      sync.RWMutex
+	cert    *tls.Certificate
+	lastErr error
+}
+
+// Destruct satisfies caddy.Destructor. The entry owns no OS resources, so
+// dropping it from the pool is all the cleanup needed.
+func (s *sharedCert) Destruct() error { return nil }
+
+// store parses freshly fetched material and makes it the served keypair.
+// Material that fails to parse is recorded but does not evict the last
+// good certificate — serving a stale-but-valid cert beats serving none.
+func (s *sharedCert) store(fullchain, key []byte) error {
+	cert, err := tls.X509KeyPair(fullchain, key)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.lastErr = err
+		return err
+	}
+	s.cert, s.lastErr = &cert, nil
+	return nil
+}
+
+// certificate returns the current keypair, or the reason there is none.
+func (s *sharedCert) certificate() (*tls.Certificate, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.cert != nil {
+		return s.cert, nil
+	}
+	if s.lastErr != nil {
+		return nil, s.lastErr
+	}
+	return nil, errNoCertYet
+}
+
+// updateHandler adapts store to the daemon's cert-change fan-out.
+func (s *sharedCert) updateHandler(certID string) client.CertificateUpdateHandler {
+	return func(fullchain, key []byte, _ *config.ClientCertification) {
+		if err := s.store(fullchain, key); err != nil {
+			logging.Error("Failed to load certificate %s: %s", certID, err)
+		}
+	}
 }
 
 // CertificateDef maps a user-defined cert id to the list of domains it should cover.
@@ -58,13 +133,81 @@ type CertDXCaddyConfig struct {
 	CertificateDefs CertificateDef `json:"certificates"`
 }
 
+// SetDefaultConfig fills in every field the user left unset. It runs both
+// from the Caddyfile adapter (on a blank module) and at the top of
+// Provision, so a native-JSON config that omits these fields gets the same
+// defaults instead of zero values — an empty AuthMethod in particular
+// would send unauthenticated requests. Empty is therefore treated as
+// unset; it is not a way to ask for the zero value.
 func (c *CertDXCaddyConfig) SetDefaultConfig() {
-	c.RetryCount = 5
-	c.Mode = config.CLIENT_MODE_HTTP
-	c.ReconnectInterval = "10m"
+	if c.RetryCount == 0 {
+		c.RetryCount = defaultRetryCount
+	}
+	if c.Mode == "" {
+		c.Mode = config.CLIENT_MODE_HTTP
+	}
+	if c.ReconnectInterval == "" {
+		c.ReconnectInterval = defaultReconnectInterval
+	}
 
-	c.Http.MainServer.AuthMethod = config.HTTP_AUTH_TOKEN
-	c.Http.StandbyServer.AuthMethod = config.HTTP_AUTH_TOKEN
+	if c.Http.MainServer.AuthMethod == "" {
+		c.Http.MainServer.AuthMethod = config.HTTP_AUTH_TOKEN
+	}
+	if c.Http.StandbyServer.AuthMethod == "" {
+		c.Http.StandbyServer.AuthMethod = config.HTTP_AUTH_TOKEN
+	}
+}
+
+// validateConfig mirrors config.ClientConfig's mode validation. The plugin
+// assembles its client config in memory instead of loading a TOML file, so
+// nothing else runs these checks: without them a missing mTLS bundle would
+// only surface at request time, long after Caddy could still roll the
+// config back.
+func (c *CertDXCaddyConfig) validateConfig() error {
+	switch c.Mode {
+	case config.CLIENT_MODE_HTTP:
+		if c.Http.MainServer.Url == "" {
+			return fmt.Errorf("http %s url is required", dirMainServer)
+		}
+		if err := validateHttpServer(&c.Http.MainServer); err != nil {
+			return fmt.Errorf("http %s: %w", dirMainServer, err)
+		}
+		if c.Http.StandbyServer.Url != "" {
+			if err := validateHttpServer(&c.Http.StandbyServer); err != nil {
+				return fmt.Errorf("http %s: %w", dirStandbyServer, err)
+			}
+		}
+	case config.CLIENT_MODE_GRPC:
+		if c.GRPC.MainServer.Server == "" {
+			return fmt.Errorf("grpc %s server is required", dirMainServer)
+		}
+		if err := c.GRPC.MainServer.Validate(); err != nil {
+			return fmt.Errorf("grpc %s: %w", dirMainServer, err)
+		}
+		if c.GRPC.StandbyServer.Server != "" {
+			if err := c.GRPC.StandbyServer.Validate(); err != nil {
+				return fmt.Errorf("grpc %s: %w", dirStandbyServer, err)
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported %s %q", dirMode, c.Mode)
+	}
+
+	return nil
+}
+
+// validateHttpServer rejects an unrecognised auth method — silently
+// falling back to "no auth" is how a typo turns into unauthenticated
+// requests — and then runs the config package's own check, which is what
+// verifies the mTLS bundle exists.
+func validateHttpServer(s *config.ClientHttpServer) error {
+	switch s.AuthMethod {
+	case config.HTTP_AUTH_TOKEN, config.HTTP_AUTH_MTLS:
+	default:
+		return fmt.Errorf("invalid %s %q, expected %q or %q",
+			dirAuthMethod, s.AuthMethod, config.HTTP_AUTH_TOKEN, config.HTTP_AUTH_MTLS)
+	}
+	return s.Validate()
 }
 
 type CertDXCaddyDaemon struct {
@@ -73,6 +216,12 @@ type CertDXCaddyDaemon struct {
 	certDXDaemon *client.CertDXClientDaemon
 	logger       *zap.Logger
 	wg           sync.WaitGroup
+
+	// certs holds this instance's view of the shared cert packs, and
+	// poolRefs the sharedCerts keys it must release on Cleanup (one entry
+	// per successful LoadOrNew, duplicates included).
+	certs    map[domain.Key]*sharedCert
+	poolRefs []domain.Key
 }
 
 func MakeCertDXCaddyDaemon() *CertDXCaddyDaemon {
@@ -89,9 +238,32 @@ func (*CertDXCaddyDaemon) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
+// acquireSharedCert takes a reference on the pool entry for one domain
+// set, creating it if this is the first config to ask for it, and records
+// the reference for Cleanup to release.
+func (m *CertDXCaddyDaemon) acquireSharedCert(key domain.Key) (*sharedCert, error) {
+	val, _, err := sharedCerts.LoadOrNew(key, func() (caddy.Destructor, error) {
+		return &sharedCert{}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	m.poolRefs = append(m.poolRefs, key)
+	return val.(*sharedCert), nil
+}
+
 func (m *CertDXCaddyDaemon) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger(m)
 	logging.SetLogger(zap.NewStdLog(m.logger))
+
+	// A native-JSON config never goes through the Caddyfile adapter, so
+	// this is the only place its defaults get applied.
+	m.SetDefaultConfig()
+
+	if err := m.validateConfig(); err != nil {
+		return err
+	}
+	m.warnInsecure()
 
 	m.certDXDaemon = client.MakeCertDXClientDaemon()
 	m.certDXDaemon.Config.Common = m.ClientCommonConfig
@@ -102,52 +274,102 @@ func (m *CertDXCaddyDaemon) Provision(ctx caddy.Context) error {
 
 	d, err := time.ParseDuration(m.ReconnectInterval)
 	if err != nil {
-		return fmt.Errorf("parse reconnect_interval %q: %w", m.ReconnectInterval, err)
+		return fmt.Errorf("parse %s %q: %w", dirReconnectInterval, m.ReconnectInterval, err)
 	}
 	m.certDXDaemon.Config.Common.ReconnectDuration = d
 
+	m.certs = make(map[domain.Key]*sharedCert, len(m.CertificateDefs))
 	for certID, domains := range m.CertificateDefs {
-		if err := m.certDXDaemon.AddCertToWatch(certID, domains); err != nil {
+		key := domain.AsKey(domains)
+		cert, err := m.acquireSharedCert(key)
+		if err != nil {
+			return fmt.Errorf("certificate %q: %w", certID, err)
+		}
+		m.certs[key] = cert
+
+		if err := m.certDXDaemon.AddCertToWatchOpt(certID, domains, []client.WatchingCertsOption{
+			client.WithCertificateHandlerOption(cert.updateHandler(certID)),
+		}); err != nil {
 			return fmt.Errorf("watch certificate %q: %w", certID, err)
 		}
 	}
 	return nil
 }
 
+// warnInsecure shouts about configurations that reach the server without
+// any credentials. It is not a hard error: a server may legitimately be
+// reachable only over a trusted network, and refusing to load would take
+// a running deployment down on upgrade.
+func (m *CertDXCaddyDaemon) warnInsecure() {
+	if m.Mode != config.CLIENT_MODE_HTTP {
+		return
+	}
+	for name, s := range map[string]*config.ClientHttpServer{
+		dirMainServer:    &m.Http.MainServer,
+		dirStandbyServer: &m.Http.StandbyServer,
+	} {
+		if s.Url == "" {
+			continue
+		}
+		if s.AuthMethod == config.HTTP_AUTH_TOKEN && s.Token == "" {
+			logging.Warn("INSECURE: http %s has %s %q but no %s, requests will be unauthenticated",
+				name, dirAuthMethod, config.HTTP_AUTH_TOKEN, dirToken)
+		}
+	}
+}
+
+// Cleanup releases this instance's references to the shared cert packs.
+// Caddy calls it on every config unload, including a failed Provision.
+func (m *CertDXCaddyDaemon) Cleanup() error {
+	var errs []error
+	for _, key := range m.poolRefs {
+		if _, err := sharedCerts.Delete(key); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	m.poolRefs = nil
+	return errors.Join(errs...)
+}
+
 func (m *CertDXCaddyDaemon) Start() error {
 	mode := m.certDXDaemon.Config.Common.Mode
 	switch mode {
 	case config.CLIENT_MODE_HTTP:
-		if m.certDXDaemon.Config.Http.MainServer.Url == "" {
-			return fmt.Errorf("http main_server url is required")
-		}
 		m.wg.Go(func() {
 			m.certDXDaemon.HttpMain()
 		})
 	case config.CLIENT_MODE_GRPC:
-		if m.certDXDaemon.Config.GRPC.MainServer.Server == "" {
-			return fmt.Errorf("grpc main_server is required")
-		}
 		m.wg.Go(func() {
 			m.certDXDaemon.GRPCMain()
 		})
 	default:
-		return fmt.Errorf("unsupported mode %q", mode)
+		return fmt.Errorf("unsupported %s %q", dirMode, mode)
 	}
 	return nil
 }
 
 func (m *CertDXCaddyDaemon) Stop() error {
+	if m.certDXDaemon == nil {
+		return nil
+	}
 	m.certDXDaemon.Stop()
 	m.wg.Wait()
 	return nil
 }
 
-func (m *CertDXCaddyDaemon) GetCertificate(ctx context.Context, certHash domain.Key) (*tls.Certificate, error) {
-	return m.certDXDaemon.GetCertificate(ctx, certHash)
+// GetCertificate returns the material of one cert pack. It reads the
+// shared pool rather than the daemon, so a just-reloaded config keeps
+// serving the previous certificate until its own first poll round lands.
+func (m *CertDXCaddyDaemon) GetCertificate(_ context.Context, certHash domain.Key) (*tls.Certificate, error) {
+	cert, ok := m.certs[certHash]
+	if !ok {
+		return nil, fmt.Errorf("no certificate definition for domain set %d", certHash)
+	}
+	return cert.certificate()
 }
 
 var (
-	_ caddy.Provisioner = (*CertDXCaddyDaemon)(nil)
-	_ caddy.App         = (*CertDXCaddyDaemon)(nil)
+	_ caddy.Provisioner  = (*CertDXCaddyDaemon)(nil)
+	_ caddy.CleanerUpper = (*CertDXCaddyDaemon)(nil)
+	_ caddy.App          = (*CertDXCaddyDaemon)(nil)
 )

--- a/exec/tools/tasks/google-account.go
+++ b/exec/tools/tasks/google-account.go
@@ -15,6 +15,7 @@ func RegisterGoogleAccount(name string, args []string) error {
 		email       = fs.StringP("email", "e", "", "Email of registration")
 		keyID       = fs.StringP("kid", "k", "", "Key id of EAB")
 		hmac        = fs.StringP("hmac", "m", "", "B64HMAC of EAB")
+		force       = fs.BoolP("force", "f", false, "Overwrite an existing ACME account key")
 		help        = fs.BoolP("help", "h", false, "Print help")
 	)
 	if err := fs.Parse(args); err != nil {
@@ -32,7 +33,7 @@ func RegisterGoogleAccount(name string, args []string) error {
 	if *testAccount {
 		provider = "googletest"
 	}
-	if err := acme.RegisterAccount(provider, *email, *keyID, *hmac); err != nil {
+	if err := acme.RegisterAccount(provider, *email, *keyID, *hmac, *force); err != nil {
 		return fmt.Errorf("register account: %w", err)
 	}
 	return nil

--- a/exec/tools/tasks/kubernetesCertificateUpdater/updater.go
+++ b/exec/tools/tasks/kubernetesCertificateUpdater/updater.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -31,12 +32,22 @@ import (
 // granted via a ClusterRole + ClusterRoleBinding (cluster-wide) since the
 // list is performed across all namespaces.
 
+// secretListPageSize is the page size used when listing TLS secrets
+// cluster-wide, keeping peak memory bounded on large clusters.
+const secretListPageSize = 500
+
 type KubernetesCertificateUpdater struct {
 	cmd *k8sCertsUpdateCmd
 
 	wg           sync.WaitGroup
 	taskErrMutex sync.Mutex
 	taskErr      []error
+
+	// pending holds the watch names (namespace/name) whose handler has been
+	// registered but has not completed yet, so a wait timeout can name the
+	// secrets that never got their certificate.
+	pendingMutex sync.Mutex
+	pending      map[string]struct{}
 
 	certDXDaemon *client.CertDXClientDaemon
 	kubeClient   kubernetes.Interface
@@ -48,6 +59,7 @@ func MakeKubernetesReplaceCertificate(updaterCmd *k8sCertsUpdateCmd) *Kubernetes
 
 		wg:           sync.WaitGroup{},
 		taskErrMutex: sync.Mutex{},
+		pending:      make(map[string]struct{}),
 
 		// certDXDaemon : in certdx init
 	}
@@ -109,7 +121,7 @@ func (r *KubernetesCertificateUpdater) InvokeCertificateUpdate(ctx context.Conte
 	}
 	defer r.certDXDaemon.Stop()
 
-	return r.waitReplaceTask()
+	return r.waitReplaceTask(ctx)
 }
 
 func (r *KubernetesCertificateUpdater) getAllCertificatesFromKubernetes(ctx context.Context) ([]corev1.Secret, error) {
@@ -117,22 +129,36 @@ func (r *KubernetesCertificateUpdater) getAllCertificatesFromKubernetes(ctx cont
 		return nil, fmt.Errorf("kubernetes client is not initialized")
 	}
 
-	raw, err := r.kubeClient.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list secrets in kubernetes: %w", err)
+	// Only TLS secrets can ever be updated, so let the apiserver do the
+	// filtering, and page through the result: a cluster-wide list of every
+	// secret would otherwise be materialized in memory at once.
+	listOpts := metav1.ListOptions{
+		FieldSelector: "type=" + string(corev1.SecretTypeTLS),
+		Limit:         secretListPageSize,
 	}
 
-	ret := make([]corev1.Secret, 0, len(raw.Items))
-	for _, secret := range raw.Items {
-		if secret.Type != corev1.SecretTypeTLS {
-			continue
+	ret := make([]corev1.Secret, 0)
+	for {
+		raw, err := r.kubeClient.CoreV1().Secrets("").List(ctx, listOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list secrets in kubernetes: %w", err)
 		}
-		if _, ok := secret.Annotations[certDxDomainAnnotation]; !ok {
-			continue
+
+		for _, secret := range raw.Items {
+			if secret.Type != corev1.SecretTypeTLS {
+				continue
+			}
+			if _, ok := secret.Annotations[certDxDomainAnnotation]; !ok {
+				continue
+			}
+			ret = append(ret, secret)
 		}
-		ret = append(ret, secret)
+
+		if raw.Continue == "" {
+			return ret, nil
+		}
+		listOpts.Continue = raw.Continue
 	}
-	return ret, nil
 }
 
 // registerWatchAndHandlers parses each annotated secret, validates its domains
@@ -160,6 +186,7 @@ func (r *KubernetesCertificateUpdater) registerWatchAndHandlers(ctx context.Cont
 
 		watchName := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
 		r.wg.Add(1)
+		r.markPending(watchName)
 
 		var once sync.Once
 		handler := func(fullchain, key []byte, _ *config.ClientCertification) {
@@ -167,6 +194,7 @@ func (r *KubernetesCertificateUpdater) registerWatchAndHandlers(ctx context.Cont
 			// the first successful delivery for this one-shot run.
 			once.Do(func() {
 				defer r.wg.Done()
+				defer r.markDone(watchName)
 				if err := r.replaceCertificateInKubernetes(ctx, secret, fullchain, key); err != nil {
 					r.taskErrMutex.Lock()
 					r.taskErr = append(r.taskErr, fmt.Errorf("%s/%s: %w", secret.Namespace, secret.Name, err))
@@ -179,6 +207,7 @@ func (r *KubernetesCertificateUpdater) registerWatchAndHandlers(ctx context.Cont
 			client.WithCertificateHandlerOption(handler),
 		}); err != nil {
 			logging.Error("Failed to add cert to watch for secret %s: %s", watchName, err)
+			r.markDone(watchName)
 			r.wg.Done()
 			continue
 		}
@@ -205,8 +234,42 @@ func (r *KubernetesCertificateUpdater) startCertDXDaemon() error {
 	return nil
 }
 
-func (r *KubernetesCertificateUpdater) waitReplaceTask() error {
-	waitCtx, cancel := context.WithTimeout(context.Background(), waitDeadline)
+func (r *KubernetesCertificateUpdater) markPending(watchName string) {
+	r.pendingMutex.Lock()
+	defer r.pendingMutex.Unlock()
+	if r.pending == nil {
+		r.pending = make(map[string]struct{})
+	}
+	r.pending[watchName] = struct{}{}
+}
+
+func (r *KubernetesCertificateUpdater) markDone(watchName string) {
+	r.pendingMutex.Lock()
+	defer r.pendingMutex.Unlock()
+	delete(r.pending, watchName)
+}
+
+// pendingWatchNames returns the sorted names of the secrets whose handler has
+// not completed yet.
+func (r *KubernetesCertificateUpdater) pendingWatchNames() []string {
+	r.pendingMutex.Lock()
+	defer r.pendingMutex.Unlock()
+	names := make([]string, 0, len(r.pending))
+	for name := range r.pending {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (r *KubernetesCertificateUpdater) collectTaskErr() []error {
+	r.taskErrMutex.Lock()
+	defer r.taskErrMutex.Unlock()
+	return append([]error(nil), r.taskErr...)
+}
+
+func (r *KubernetesCertificateUpdater) waitReplaceTask(ctx context.Context) error {
+	waitCtx, cancel := context.WithTimeout(ctx, waitDeadline)
 	defer cancel()
 
 	wgDone := make(chan struct{})
@@ -217,15 +280,18 @@ func (r *KubernetesCertificateUpdater) waitReplaceTask() error {
 
 	select {
 	case <-waitCtx.Done():
-		return fmt.Errorf("timeout waiting for kubernetes secrets to be updated")
+		// Report both what already failed and which secrets never got a
+		// certificate; otherwise the run fails with a bare, unactionable timeout.
+		pending := r.pendingWatchNames()
+		errs := append([]error{fmt.Errorf("stopped waiting for kubernetes secrets to be updated (%w), %d pending: [%s]",
+			context.Cause(waitCtx), len(pending), strings.Join(pending, ", "))}, r.collectTaskErr()...)
+		return errors.Join(errs...)
 	case <-wgDone:
-		r.taskErrMutex.Lock()
-		defer r.taskErrMutex.Unlock()
-		if len(r.taskErr) == 0 {
-			logging.Info("All kubernetes secrets updated successfully")
-			return nil
+		if errs := r.collectTaskErr(); len(errs) != 0 {
+			return errors.Join(errs...)
 		}
-		return errors.Join(r.taskErr...)
+		logging.Info("All kubernetes secrets updated successfully")
+		return nil
 	}
 }
 
@@ -287,9 +353,12 @@ func parseDomainsAnnotation(domainListStr string) []string {
 	return ret
 }
 
+// areDomainsAllowed reports whether one configured cert pack covers every
+// annotated domain. The configured lists are cert-pack domains, so wildcard
+// entries must be honoured (a "*.example.com" pack covers "foo.example.com").
 func areDomainsAllowed(certdx *client.CertDXClientDaemon, domains []string) bool {
 	for _, item := range certdx.Config.Certifications {
-		if domain.AllAllowed(item.Domains, domains) {
+		if domain.AllCovered(item.Domains, domains) {
 			return true
 		}
 	}

--- a/exec/tools/tasks/kubernetesCertificateUpdater/updater_test.go
+++ b/exec/tools/tasks/kubernetesCertificateUpdater/updater_test.go
@@ -3,15 +3,19 @@ package kubernetesCertificateUpdater
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"pkg.para.party/certdx/pkg/api"
 	"pkg.para.party/certdx/pkg/client"
 	"pkg.para.party/certdx/pkg/config"
@@ -88,5 +92,126 @@ func TestDuplicateDomainSecretsShareWatchAndAllUpdate(t *testing.T) {
 		if got := string(secret.Data[corev1.TLSPrivateKeyKey]); got != "new-key" {
 			t.Errorf("secret %s tls.key = %q, want %q", name, got, "new-key")
 		}
+	}
+}
+
+func TestRegisterWatchAndHandlersAcceptsWildcardCoveredDomains(t *testing.T) {
+	// The shipped config/client_k8s.toml cert pack, which only lists wildcards.
+	daemon := client.MakeCertDXClientDaemon()
+	daemon.Config.Certifications = []config.ClientCertification{{
+		Name:    "domainsToWatch",
+		Domains: []string{"*.example.com", "*.mm.example.com"},
+	}}
+
+	newSecret := func(name, annotation string) corev1.Secret {
+		return corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   "edge",
+				Name:        name,
+				Annotations: map[string]string{certDxDomainAnnotation: annotation},
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+	}
+	covered := newSecret("covered", "foo.example.com,foo.mm.example.com")
+	wildcard := newSecret("wildcard", "*.example.com")
+	nested := newSecret("nested", "deep.nested.example.com")
+	// A wildcard-only pack carries no apex SAN (RFC 6125), so a secret that
+	// wants the apex is not covered by it and must be skipped.
+	apex := newSecret("apex", "example.com")
+
+	updater := MakeKubernetesReplaceCertificate(&k8sCertsUpdateCmd{})
+	updater.certDXDaemon = daemon
+	updater.kubeClient = fake.NewSimpleClientset()
+
+	registered := updater.registerWatchAndHandlers(context.Background(),
+		[]corev1.Secret{covered, wildcard, nested, apex})
+	if registered != 2 {
+		t.Fatalf("registered secrets = %d, want 2 (wildcard cert pack must cover subdomains)", registered)
+	}
+
+	pending := updater.pendingWatchNames()
+	if len(pending) != 2 || pending[0] != "edge/covered" || pending[1] != "edge/wildcard" {
+		t.Fatalf("pending watches = %v, want [edge/covered edge/wildcard]", pending)
+	}
+	for range pending {
+		updater.wg.Done()
+	}
+}
+
+func TestGetAllCertificatesFromKubernetesFiltersServerSideAndPaginates(t *testing.T) {
+	annotated := func(name string) corev1.Secret {
+		return corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   "edge",
+				Name:        name,
+				Annotations: map[string]string{certDxDomainAnnotation: "foo.example.com"},
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+	}
+
+	kube := fake.NewSimpleClientset()
+	var fieldSelectors []string
+	var calls int
+	kube.PrependReactor("list", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction, ok := action.(k8stesting.ListActionImpl)
+		if !ok {
+			t.Errorf("unexpected action type %T", action)
+			return false, nil, nil
+		}
+		fieldSelectors = append(fieldSelectors, listAction.GetListRestrictions().Fields.String())
+		calls++
+		if calls == 1 {
+			return true, &corev1.SecretList{
+				ListMeta: metav1.ListMeta{Continue: "page-2"},
+				Items: []corev1.Secret{
+					annotated("first"),
+					{ObjectMeta: metav1.ObjectMeta{Namespace: "edge", Name: "unannotated"}, Type: corev1.SecretTypeTLS},
+				},
+			}, nil
+		}
+		return true, &corev1.SecretList{Items: []corev1.Secret{annotated("second")}}, nil
+	})
+
+	updater := MakeKubernetesReplaceCertificate(&k8sCertsUpdateCmd{})
+	updater.kubeClient = kube
+
+	got, err := updater.getAllCertificatesFromKubernetes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("list calls = %d, want 2 (the continue token must be followed)", calls)
+	}
+	for _, selector := range fieldSelectors {
+		if selector != "type=kubernetes.io/tls" {
+			t.Fatalf("field selector = %q, want type=kubernetes.io/tls", selector)
+		}
+	}
+	if len(got) != 2 || got[0].Name != "first" || got[1].Name != "second" {
+		t.Fatalf("secrets = %v, want the annotated secrets of both pages", got)
+	}
+}
+
+func TestWaitReplaceTaskTimeoutReportsPendingAndErrors(t *testing.T) {
+	updater := MakeKubernetesReplaceCertificate(&k8sCertsUpdateCmd{})
+	updater.wg.Add(1)
+	defer updater.wg.Done()
+	updater.markPending("edge/never-delivered")
+	updater.taskErr = append(updater.taskErr, fmt.Errorf("edge/failed: update rejected"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := updater.waitReplaceTask(ctx)
+	if err == nil {
+		t.Fatal("expected wait to fail")
+	}
+	if !strings.Contains(err.Error(), "edge/never-delivered") {
+		t.Errorf("error %q does not name the pending secret", err)
+	}
+	if !strings.Contains(err.Error(), "edge/failed: update rejected") {
+		t.Errorf("error %q drops the already accumulated per-secret error", err)
 	}
 }

--- a/exec/tools/tasks/make-ca.go
+++ b/exec/tools/tasks/make-ca.go
@@ -13,6 +13,7 @@ func MakeCA(name string, args []string) error {
 	var (
 		org        = fs.StringP("organization", "o", "CertDX Private", "Subject Organization")
 		commonName = fs.StringP("common-name", "c", "CertDX Private Certificate Authority", "Subject Common Name")
+		validFor   = fs.Duration("valid-for", tools.DefaultCALifetime, "Certificate validity period")
 		dataDir    = registerDataDirFlag(fs)
 		help       = fs.BoolP("help", "h", false, "Print help")
 	)
@@ -24,9 +25,16 @@ func MakeCA(name string, args []string) error {
 		return nil
 	}
 
+	// tools.WithLifetime silently keeps the default for a non-positive
+	// duration, which would hide a typo like "--valid-for -1h" or
+	// "--valid-for 0". Reject it here instead.
+	if *validFor <= 0 {
+		return fmt.Errorf("--valid-for must be positive, got %s", *validFor)
+	}
+
 	applyDataDir(*dataDir)
 
-	if err := tools.MakeCA(*org, *commonName); err != nil {
+	if err := tools.MakeCA(*org, *commonName, tools.WithLifetime(*validFor)); err != nil {
 		return fmt.Errorf("create CA: %w", err)
 	}
 	return nil

--- a/exec/tools/tasks/make-client.go
+++ b/exec/tools/tasks/make-client.go
@@ -19,6 +19,7 @@ func MakeClient(name string, args []string) error {
 		domains    = fs.StringSliceP("dns-names", "d", []string{}, "Client certificate DNS names (comma-separated)")
 		org        = fs.StringP("organization", "o", "CertDX Private", "Subject Organization")
 		commonName = fs.StringP("common-name", "c", commonNameTemplate, "Subject Common Name")
+		validFor   = fs.Duration("valid-for", tools.DefaultLeafLifetime, "Certificate validity period")
 		dataDir    = registerDataDirFlag(fs)
 		help       = fs.BoolP("help", "h", false, "Print help")
 	)
@@ -33,11 +34,19 @@ func MakeClient(name string, args []string) error {
 	if *clientName == "" {
 		return fmt.Errorf("--name is required")
 	}
+
+	// tools.WithLifetime silently keeps the default for a non-positive
+	// duration, which would hide a typo like "--valid-for -1h" or
+	// "--valid-for 0". Reject it here instead.
+	if *validFor <= 0 {
+		return fmt.Errorf("--valid-for must be positive, got %s", *validFor)
+	}
+
 	cn := strings.ReplaceAll(*commonName, "{name}", *clientName)
 
 	applyDataDir(*dataDir)
 
-	if err := tools.MakeClientCert(*clientName, *org, cn, *domains); err != nil {
+	if err := tools.MakeClientCert(*clientName, *org, cn, *domains, tools.WithLifetime(*validFor)); err != nil {
 		return fmt.Errorf("create client cert: %w", err)
 	}
 	return nil

--- a/exec/tools/tasks/make-server.go
+++ b/exec/tools/tasks/make-server.go
@@ -14,6 +14,7 @@ func MakeServer(name string, args []string) error {
 		domains    = fs.StringSliceP("dns-names", "d", []string{}, "Server certificate DNS names (comma-separated)")
 		org        = fs.StringP("organization", "o", "CertDX Private", "Subject Organization")
 		commonName = fs.StringP("common-name", "c", "CertDX Secret Discovery Service", "Subject Common Name")
+		validFor   = fs.Duration("valid-for", tools.DefaultLeafLifetime, "Certificate validity period")
 		dataDir    = registerDataDirFlag(fs)
 		help       = fs.BoolP("help", "h", false, "Print help")
 	)
@@ -33,9 +34,16 @@ func MakeServer(name string, args []string) error {
 		return fmt.Errorf("--dns-names is required")
 	}
 
+	// tools.WithLifetime silently keeps the default for a non-positive
+	// duration, which would hide a typo like "--valid-for -1h" or
+	// "--valid-for 0". Reject it here instead.
+	if *validFor <= 0 {
+		return fmt.Errorf("--valid-for must be positive, got %s", *validFor)
+	}
+
 	applyDataDir(*dataDir)
 
-	if err := tools.MakeServerCert(*serverName, *org, *commonName, *domains); err != nil {
+	if err := tools.MakeServerCert(*serverName, *org, *commonName, *domains, tools.WithLifetime(*validFor)); err != nil {
 		return fmt.Errorf("create server cert: %w", err)
 	}
 	return nil

--- a/exec/tools/tasks/txcCertificateUpdater/task.go
+++ b/exec/tools/tasks/txcCertificateUpdater/task.go
@@ -3,6 +3,8 @@ package txcCertificateUpdater
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	flag "github.com/spf13/pflag"
 
@@ -37,7 +39,16 @@ func TencentCloudReplaceCertificate(name string, args []string) error {
 	if err := updater.InitCertificateUpdater(); err != nil {
 		return fmt.Errorf("init updater: %w", err)
 	}
-	if err := updater.InvokeCertificateUpdate(context.Background()); err != nil {
+
+	// The run is bounded so an unreachable or rejecting Tencent Cloud
+	// endpoint exits nonzero for cron alerting instead of hanging, and a
+	// SIGINT/SIGTERM cancels the in-flight API calls.
+	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stopSignals()
+	ctx, cancel := context.WithTimeout(ctx, waitDeadline)
+	defer cancel()
+
+	if err := updater.InvokeCertificateUpdate(ctx); err != nil {
 		return fmt.Errorf("update certificates: %w", err)
 	}
 	return nil

--- a/exec/tools/tasks/txcCertificateUpdater/updater.go
+++ b/exec/tools/tasks/txcCertificateUpdater/updater.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	txprofile "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
 	"pkg.para.party/certdx/pkg/cli"
@@ -26,6 +28,33 @@ const updateRetryCount = 3
 // describeRetryCount bounds DescribeCertificates pagination retries.
 const describeRetryCount = 3
 
+const (
+	// waitDeadline bounds a whole updater run — an unreachable or
+	// rejecting Tencent Cloud endpoint must surface as a nonzero exit
+	// for cron alerting instead of hanging forever.
+	waitDeadline = 10 * time.Minute
+
+	// deployConfirmTimeout bounds the poll for one UpdateCertificateInstance
+	// deploy record; deployPollInterval is the gap between polls.
+	deployConfirmTimeout = 5 * time.Minute
+	deployPollInterval   = 10 * time.Second
+
+	// deployRecordAppearTimeout bounds the sub-case where the record
+	// detail keeps coming back empty: with nothing to confirm there is
+	// no point burning the whole deployConfirmTimeout before saying so.
+	deployRecordAppearTimeout = 90 * time.Second
+
+	// txcFastFailThreshold mirrors retry.Do's fast-fail floor: a failure
+	// arriving faster than this is deterministic unless it is one of the
+	// recognizably transient SDK codes.
+	txcFastFailThreshold = time.Second
+
+	// txcTransientBackoff is the first backoff for a transient SDK
+	// failure (throttling, InternalError, network/5xx). It doubles per
+	// attempt, capped at retry.Interval.
+	txcTransientBackoff = 2 * time.Second
+)
+
 type TencentCloudCertificateUpdater struct {
 	cmd *txcCertsUpdateCmd
 
@@ -37,6 +66,14 @@ type TencentCloudCertificateUpdater struct {
 	taskErr      []error
 	certDXDaemon *client.CertDXClientDaemon
 
+	// oldCertEnd maps an expiring certificate id to its parsed
+	// CertEndTime. It is the per-task companion of
+	// ClientCertification.oldCertificateId — the rebind path needs the
+	// expiry of the certificate it is replacing to reject a stale
+	// replacement. Written once in GetCertificateToUpdate, read-only
+	// afterwards.
+	oldCertEnd map[string]time.Time
+
 	// ctx is captured from InvokeCertificateUpdate so the per-cert
 	// retry callbacks (closures the certdx daemon invokes on update)
 	// and the paged DescribeCertificates retries can share a single
@@ -47,27 +84,57 @@ type TencentCloudCertificateUpdater struct {
 
 func MakeTencentCloudCertificateUpdater(updaterCmd *txcCertsUpdateCmd) *TencentCloudCertificateUpdater {
 	return &TencentCloudCertificateUpdater{
-		cmd: updaterCmd,
-		cfg: &TencentCloudConfig{},
+		cmd:        updaterCmd,
+		cfg:        &TencentCloudConfig{},
+		oldCertEnd: make(map[string]time.Time),
 	}
 }
 
-func isActivatingCertificateExists(activatingCertificates []*txssl.Certificates, cert *txssl.Certificates) (*txssl.Certificates, error) {
+// findReplacementCertificate returns the certificate that already
+// supersedes cert: same SAN set, a strictly later CertEndTime, and not
+// itself in the expiring set. Matching on the SAN set alone was wrong —
+// the activating list also contains the expiring certs, so two same-SAN
+// expiring certs used to suppress each other and neither was renewed.
+// Anything we cannot prove is a valid replacement (unparsable expiry, a
+// same-SAN peer that is also expiring) returns nil so cert still renews.
+func findReplacementCertificate(activatingCertificates []*txssl.Certificates, cert *txssl.Certificates,
+	expiringIds map[string]struct{}) (*txssl.Certificates, error) {
 	if cert == nil {
 		return nil, fmt.Errorf("certificate is nil")
 	}
+	certEnd, ok := parseTxcTime(cert.CertEndTime)
+	if !ok {
+		logging.Warn("Certificate has no parsable CertEndTime, treating it as not replaced")
+		return nil, nil
+	}
+
+	var (
+		newest    *txssl.Certificates
+		newestEnd time.Time
+	)
 	for _, ac := range activatingCertificates {
-		if ac == nil {
-			return nil, fmt.Errorf("activatingCertificates contains nil certificate")
-		}
-		if ac.CertificateId != nil && cert.CertificateId != nil && *ac.CertificateId == *cert.CertificateId {
+		if ac == nil || ac.CertificateId == nil {
+			logging.Warn("Skipping certificate without id while looking for a replacement")
 			continue
 		}
-		if isSameStrSetRejectNilItemPtrArrPtrArr(ac.CertSANs, cert.CertSANs) {
-			return ac, nil
+		if cert.CertificateId != nil && *ac.CertificateId == *cert.CertificateId {
+			continue
+		}
+		if _, expiring := expiringIds[*ac.CertificateId]; expiring {
+			continue
+		}
+		if !isSameStrSetRejectNilItemPtrArrPtrArr(ac.CertSANs, cert.CertSANs) {
+			continue
+		}
+		acEnd, ok := parseTxcTime(ac.CertEndTime)
+		if !ok || !acEnd.After(certEnd) {
+			continue
+		}
+		if newest == nil || acEnd.After(newestEnd) {
+			newest, newestEnd = ac, acEnd
 		}
 	}
-	return nil, nil
+	return newest, nil
 }
 
 func (r *TencentCloudCertificateUpdater) GetCertificateToUpdate() error {
@@ -93,14 +160,27 @@ func (r *TencentCloudCertificateUpdater) GetCertificateToUpdate() error {
 		return fmt.Errorf("fetch activating certificates: %w", err)
 	}
 
+	// The activating list is a superset of the expiring one; a same-SAN
+	// peer that is itself expiring is not a replacement.
+	expiringIds := make(map[string]struct{}, len(expiringCertificates))
+	for _, expiringCert := range expiringCertificates {
+		if expiringCert == nil || expiringCert.CertificateId == nil {
+			continue
+		}
+		expiringIds[*expiringCert.CertificateId] = struct{}{}
+	}
+
 	matchedCerts := make([]ClientCertification, 0)
+	if r.oldCertEnd == nil {
+		r.oldCertEnd = make(map[string]time.Time)
+	}
 
 	for _, expiringCert := range expiringCertificates {
-		if expiringCert.CertificateId == nil {
+		if expiringCert == nil || expiringCert.CertificateId == nil {
 			logging.Error("Unexpected nil certificate id")
 			continue
 		}
-		activatingCertificate, err := isActivatingCertificateExists(activatingCertificates, expiringCert)
+		activatingCertificate, err := findReplacementCertificate(activatingCertificates, expiringCert, expiringIds)
 		if err != nil {
 			logging.Error("Failed to check activating certificate: %s", err)
 			continue
@@ -116,6 +196,12 @@ func (r *TencentCloudCertificateUpdater) GetCertificateToUpdate() error {
 			if isSameStrSetRejectNilItem(fetchedCertSANs, cert.Domains) {
 				cert.oldCertificateId = *expiringCert.CertificateId
 				cert.certDxKey = domain.AsKey(cert.Domains)
+				// Remember when the certificate being replaced expires:
+				// the rebind path must not settle for a stored
+				// certificate that expires no later than this one.
+				if end, ok := parseTxcTime(expiringCert.CertEndTime); ok {
+					r.oldCertEnd[cert.oldCertificateId] = end
+				}
 				matchedCerts = append(matchedCerts, cert)
 			}
 		}
@@ -148,8 +234,9 @@ func (r *TencentCloudCertificateUpdater) AddReplaceTask() error {
 
 // makeReplaceHandler returns the per-cert callback the certdx daemon
 // fires on each cert update. It posts the new cert to Tencent Cloud
-// SSL with retries (cancellable via r.ctx) and signals the outer
-// WaitGroup whether the call succeeded or not.
+// SSL with retries (cancellable via r.ctx), waits for the resulting
+// deploy record to be confirmed, and signals the outer WaitGroup
+// whether the replacement succeeded or not.
 func (r *TencentCloudCertificateUpdater) makeReplaceHandler(taskCert ClientCertification) client.CertificateUpdateHandler {
 	return func(fullchain, key []byte, _ *config.ClientCertification) {
 		defer r.wg.Done()
@@ -162,33 +249,243 @@ func (r *TencentCloudCertificateUpdater) makeReplaceHandler(taskCert ClientCerti
 		req.ExpiringNotificationSwitch = txcommon.Uint64Ptr(1)
 		req.Repeatable = txcommon.BoolPtr(false)
 
-		err := retry.Do(r.ctx, updateRetryCount, func() error {
-			resp, err := r.client.UpdateCertificateInstance(req)
+		err := r.callTxcAPI(updateRetryCount, "UpdateCertificateInstance", func() error {
+			resp, err := r.client.UpdateCertificateInstanceWithContext(r.ctx, req)
 			if err != nil {
 				var sdkErr *txerr.TencentCloudSDKError
 				if errors.As(err, &sdkErr) && sdkErr.Code == "FailedOperation.CertificateExists" {
-					logging.Warn("Certificate already exists, skipping upload (code=%s message=%s requestId=%s)",
+					// The certificate is already in the Tencent Cloud
+					// store from an earlier partial run, but nothing was
+					// re-bound: the resources still point at the expiring
+					// cert. Rebind them against the stored certificate
+					// instead of reporting a no-op as success.
+					logging.Warn("Certificate already uploaded (code=%s message=%s requestId=%s), rebinding resources to the stored certificate",
 						sdkErr.Code, sdkErr.Message, sdkErr.RequestId)
-					return nil
+					return r.rebindExistingCertificate(taskCert)
 				}
 				return fmt.Errorf("UpdateCertificateInstance: %w", err)
 			}
 			logging.Debug("UpdateCertificateInstance requestId=%s", *resp.Response.RequestId)
-			return nil
+			return r.waitDeployRecord(taskCert.Name, resp.Response.DeployRecordId)
 		})
 
 		if err != nil {
 			r.taskErrMu.Lock()
-			r.taskErr = append(r.taskErr, err)
+			r.taskErr = append(r.taskErr, fmt.Errorf("replace cert %q: %w", taskCert.Name, err))
 			r.taskErrMu.Unlock()
 		}
 	}
 }
 
+// rebindExistingCertificate handles FailedOperation.CertificateExists:
+// it looks up the certificate Tencent Cloud already stores for the same
+// domains and re-issues UpdateCertificateInstance against that id, then
+// waits for the deploy record so the rebind is confirmed rather than
+// assumed.
+func (r *TencentCloudCertificateUpdater) rebindExistingCertificate(taskCert ClientCertification) error {
+	newCertificateId, err := r.findUploadedCertificate(taskCert)
+	if err != nil {
+		return fmt.Errorf("locate already uploaded certificate: %w", err)
+	}
+	logging.Info("Rebinding resources of cert id %s to already uploaded cert id %s", taskCert.oldCertificateId, newCertificateId)
+
+	req := txssl.NewUpdateCertificateInstanceRequest()
+	req.OldCertificateId = txcommon.StringPtr(taskCert.oldCertificateId)
+	req.CertificateId = txcommon.StringPtr(newCertificateId)
+	req.ResourceTypes, req.ResourceTypesRegions = taskCert.ToResourceTypesAndResourceTypesRegions()
+	req.ExpiringNotificationSwitch = txcommon.Uint64Ptr(1)
+
+	resp, err := r.client.UpdateCertificateInstanceWithContext(r.ctx, req)
+	if err != nil {
+		return fmt.Errorf("UpdateCertificateInstance (rebind to %s): %w", newCertificateId, err)
+	}
+	logging.Debug("UpdateCertificateInstance (rebind) requestId=%s", *resp.Response.RequestId)
+
+	return r.waitDeployRecord(taskCert.Name, resp.Response.DeployRecordId)
+}
+
+// findUploadedCertificate returns the id of the newest certificate
+// Tencent Cloud holds for taskCert's domains, excluding the expiring one
+// being replaced and anything that does not outlive it. The lookup runs
+// with FilterExpiring=0, so expiring certificates are in the result set
+// too — without the expiry guard a rebind could point every resource at
+// a staler certificate and then confirm that as a success.
+func (r *TencentCloudCertificateUpdater) findUploadedCertificate(taskCert ClientCertification) (string, error) {
+	certificates, err := r.FetchTencentCloudCertificate(func(req *txssl.DescribeCertificatesRequest) {
+		req.CertificateType = txcommon.StringPtr("SVR")          // 服务端证书
+		req.CertificateStatus = []*uint64{txcommon.Uint64Ptr(1)} // 正常状态的证书
+		req.FilterSource = txcommon.StringPtr("upload")          // 上传的证书
+		req.FilterExpiring = txcommon.Uint64Ptr(0)               // 临期证书和非临期证书
+	})
+	if err != nil {
+		return "", err
+	}
+
+	oldEnd := r.oldCertEndTime(taskCert.oldCertificateId)
+	if oldEnd.IsZero() {
+		logging.Warn("Expiry of cert id %s is unknown, cannot check the stored certificate is newer than it",
+			taskCert.oldCertificateId)
+	}
+	return pickNewerUploadedCertificate(certificates, taskCert.Domains, taskCert.oldCertificateId, oldEnd)
+}
+
+// oldCertEndTime returns the parsed CertEndTime of the expiring
+// certificate with the given id, or the zero time when it was never
+// recorded (unparsable timestamp, or a task built outside
+// GetCertificateToUpdate). The map is filled before any handler runs and
+// only read afterwards, so it needs no lock.
+func (r *TencentCloudCertificateUpdater) oldCertEndTime(certificateId string) time.Time {
+	return r.oldCertEnd[certificateId]
+}
+
+// waitDeployRecord polls the host-update record of an
+// UpdateCertificateInstance task until every resource has been
+// re-bound. A created task is not a replaced certificate: without this
+// poll a failed deploy would leave the resources on the expiring cert
+// while the run reported success.
+//
+// Anything it can prove — resources failed, the record never listed a
+// resource, the deploy never settled — comes back wrapped in
+// [errTxcTerminal] so callTxcAPI reports it instead of replaying the
+// upload. "No record yet" is the one retryable outcome, and a missing
+// CAM permission for the (read-only) confirmation call downgrades to a
+// warning rather than failing a deploy that Tencent Cloud accepted.
+func (r *TencentCloudCertificateUpdater) waitDeployRecord(certName string, deployRecordId *uint64) error {
+	if deployRecordId == nil || *deployRecordId == 0 {
+		// DeployRecordId == 0 means the task has not been created yet;
+		// the SDK contract is to repeat the request.
+		return fmt.Errorf("%w: deploy task for cert %q not created yet", errTxcRetryable, certName)
+	}
+
+	id := strconv.FormatUint(*deployRecordId, 10)
+	start := time.Now()
+	deadline := start.Add(deployConfirmTimeout)
+	sawResources := false
+
+	for {
+		req := txssl.NewDescribeHostUpdateRecordDetailRequest()
+		req.DeployRecordId = txcommon.StringPtr(id)
+
+		resp, err := r.client.DescribeHostUpdateRecordDetailWithContext(r.ctx, req)
+		if err != nil {
+			switch {
+			case isTxcPermissionError(err):
+				// The deploy itself was accepted; only the read-only
+				// confirmation is forbidden. Accounts whose CAM policy
+				// predates this poll must not start failing their runs
+				// over it — warn loudly and stop confirming.
+				logging.Warn("Not allowed to read deploy record %s for cert %q (%s); "+
+					"grant ssl:DescribeHostUpdateRecordDetail to have the update confirmed instead of assumed", id, certName, err)
+				return nil
+			case !isTransientTxcError(err):
+				return fmt.Errorf("DescribeHostUpdateRecordDetail %s: %w", id, err)
+			default:
+				logging.Warn("DescribeHostUpdateRecordDetail %s errored transiently: %s", id, err)
+			}
+		} else {
+			detail := resp.Response
+			failed := int64OrZero(detail.FailedTotalCount)
+			pending := int64OrZero(detail.RunningTotalCount) + int64OrZero(detail.PendingTotalCount)
+			sawResources = sawResources || deployRecordListsResources(detail)
+
+			if pending == 0 && sawResources {
+				if failed > 0 {
+					// Confirmed and final: re-uploading the certificate
+					// and re-deploying cannot turn these failures into
+					// successes, so this must not be retried.
+					return fmt.Errorf("%w: deploy record %s for cert %q: %d resource(s) failed to update",
+						errTxcTerminal, id, certName, failed)
+				}
+				logging.Info("Deploy record %s for cert %q confirmed, %d resource(s) updated",
+					id, certName, int64OrZero(detail.SuccessTotalCount))
+				return nil
+			}
+			if !sawResources && time.Since(start) >= deployRecordAppearTimeout {
+				return fmt.Errorf("%w: could not confirm deploy record %s for cert %q: "+
+					"no resource listed after %s", errTxcTerminal, id, certName, deployRecordAppearTimeout)
+			}
+			logging.Debug("Deploy record %s for cert %q still running, pending=%d failed=%d", id, certName, pending, failed)
+		}
+
+		if time.Now().After(deadline) {
+			if !sawResources {
+				return fmt.Errorf("%w: could not confirm deploy record %s for cert %q: "+
+					"no resource listed after %s", errTxcTerminal, id, certName, deployConfirmTimeout)
+			}
+			// Still pending after the confirmation window: a retry would
+			// only repeat the upload and wait again, and the whole run is
+			// bounded by waitDeadline anyway.
+			return fmt.Errorf("%w: timeout confirming deploy record %s for cert %q after %s",
+				errTxcTerminal, id, certName, deployConfirmTimeout)
+		}
+
+		select {
+		case <-time.After(deployPollInterval):
+		case <-r.ctx.Done():
+			return fmt.Errorf("wait deploy record %s for cert %q: %w", id, certName, r.ctx.Err())
+		}
+	}
+}
+
+// callTxcAPI runs a Tencent Cloud SDK call with bounded retries. It
+// keeps retry.Do's fast-fail rule for deterministic failures but adds a
+// backoff path for recognizably transient ones (throttling,
+// InternalError, network/5xx) — those return in well under a second, so
+// retry.Do alone would give up before the retry budget ever engaged.
+func (r *TencentCloudCertificateUpdater) callTxcAPI(retryCount int, what string, work func() error) error {
+	if err := r.ctx.Err(); err != nil {
+		return err
+	}
+
+	var err error
+	for attempt := 0; ; attempt++ {
+		begin := time.Now()
+		err = work()
+		if err == nil {
+			return nil
+		}
+
+		// A terminal verdict is never retried, however long it took to
+		// arrive. Deploy-record confirmation polls for minutes, so the
+		// elapsed-time heuristic below would classify its "these
+		// resources failed" answer as retryable and replay the whole
+		// upload + deploy until the run budget was gone.
+		if isTerminalTxcError(err) {
+			return fmt.Errorf("%s failed terminally, not retrying. error is: %w", what, err)
+		}
+
+		transient := isTransientTxcError(err)
+		if !transient && time.Since(begin) < txcFastFailThreshold {
+			return fmt.Errorf("%s errored too fast, give up retry. last error is: %w", what, err)
+		}
+
+		if attempt >= retryCount {
+			break
+		}
+
+		wait := retry.Interval
+		if transient {
+			wait = txcTransientBackoff << attempt
+			if wait > retry.Interval {
+				wait = retry.Interval
+			}
+		}
+		logging.Warn("%s retry %d/%d in %s, errored: %s", what, attempt+1, retryCount, wait, err)
+
+		select {
+		case <-time.After(wait):
+		case <-r.ctx.Done():
+			return fmt.Errorf("%s retry cancelled: %w", what, r.ctx.Err())
+		}
+	}
+
+	return fmt.Errorf("%s errored too many times, give up retry. last error is: %w", what, err)
+}
+
 // WaitReplaceTask blocks until every registered handler has completed
-// or ctx fires. Cancellation is driven by the caller's ctx — a Stop
-// signal propagates through directly instead of through the previous
-// hard-coded one-hour internal timeout.
+// or ctx fires. Cancellation is driven by the caller's ctx, which the
+// entrypoint bounds with [waitDeadline] and wires to SIGINT/SIGTERM, so
+// an unreachable server ends the run instead of hanging it.
 func (r *TencentCloudCertificateUpdater) WaitReplaceTask(ctx context.Context) error {
 	wgDone := make(chan struct{})
 	go func() {
@@ -198,16 +495,27 @@ func (r *TencentCloudCertificateUpdater) WaitReplaceTask(ctx context.Context) er
 
 	select {
 	case <-ctx.Done():
-		return fmt.Errorf("wait for certificate replacement: %w", ctx.Err())
+		// Report what already failed alongside the deadline; a bare
+		// "context deadline exceeded" hides which certificate or
+		// resource actually went wrong.
+		errs := append([]error{fmt.Errorf("wait for certificate replacement: %w", ctx.Err())}, r.collectTaskErr()...)
+		return errors.Join(errs...)
 	case <-wgDone:
-		r.taskErrMu.Lock()
-		defer r.taskErrMu.Unlock()
-		if len(r.taskErr) == 0 {
-			logging.Info("Certificates replaced successfully")
-			return nil
+		if errs := r.collectTaskErr(); len(errs) != 0 {
+			return errors.Join(errs...)
 		}
-		return errors.Join(r.taskErr...)
+		logging.Info("Certificates replaced successfully")
+		return nil
 	}
+}
+
+// collectTaskErr snapshots the errors recorded by the per-cert handlers.
+// Handlers may still be running when the deadline branch reads them, so
+// the copy is taken under the mutex.
+func (r *TencentCloudCertificateUpdater) collectTaskErr() []error {
+	r.taskErrMu.Lock()
+	defer r.taskErrMu.Unlock()
+	return append([]error(nil), r.taskErr...)
 }
 
 func (r *TencentCloudCertificateUpdater) FetchTencentCloudCertificate(opt func(request *txssl.DescribeCertificatesRequest)) ([]*txssl.Certificates, error) {
@@ -223,8 +531,8 @@ func (r *TencentCloudCertificateUpdater) FetchTencentCloudCertificate(opt func(r
 		req.Limit = txcommon.Uint64Ptr(pageSize)
 
 		noMoreResult := false
-		err := retry.Do(r.ctx, describeRetryCount, func() error {
-			resp, err := r.client.DescribeCertificates(req)
+		err := r.callTxcAPI(describeRetryCount, "DescribeCertificates", func() error {
+			resp, err := r.client.DescribeCertificatesWithContext(r.ctx, req)
 			if err != nil {
 				return fmt.Errorf("DescribeCertificates: %w", err)
 			}

--- a/exec/tools/tasks/txcCertificateUpdater/util.go
+++ b/exec/tools/tasks/txcCertificateUpdater/util.go
@@ -1,16 +1,99 @@
 package txcCertificateUpdater
 
-func isSameStrSetIgnoringNil(a, b []string) bool {
-	if len(a) != len(b) {
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	txerr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	txssl "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssl/v20191205"
+)
+
+// txcTimeLayout is the timestamp format Tencent Cloud SSL returns in
+// CertBeginTime / CertEndTime.
+const txcTimeLayout = "2006-01-02 15:04:05"
+
+// txcTimeZone is the zone those zone-less timestamps are expressed in.
+// Tencent Cloud reports Beijing time (UTC+8); parsing them as UTC made
+// them compare eight hours off against the RFC3339 values that do carry
+// an offset.
+var txcTimeZone = time.FixedZone("CST", 8*60*60)
+
+// errTxcRetryable marks a condition the local retry loop must treat as
+// transient even though no SDK error code is involved (e.g. a deploy
+// task that Tencent Cloud has not created yet).
+var errTxcRetryable = errors.New("retryable tencent cloud condition")
+
+// errTxcTerminal is the mirror image of [errTxcRetryable]: a confirmed,
+// non-retryable outcome that arrives *after* callTxcAPI's fast-fail
+// window. Deploy-record confirmation polls for minutes, so without this
+// marker its verdict ("these resources failed", "no record ever
+// appeared") looked like a slow, possibly transient failure and the
+// whole upload + deploy was replayed until the run budget was gone.
+var errTxcTerminal = errors.New("terminal tencent cloud failure")
+
+// isTerminalTxcError reports whether err carries the [errTxcTerminal]
+// marker and must therefore never be retried.
+func isTerminalTxcError(err error) bool {
+	return err != nil && errors.Is(err, errTxcTerminal)
+}
+
+// isTxcPermissionError reports whether err is Tencent Cloud refusing the
+// action for lack of a CAM permission (as opposed to bad credentials).
+// Used to keep an optional, read-only confirmation call from turning a
+// successful deploy into a failed run on accounts whose policy predates
+// the confirmation step.
+func isTxcPermissionError(err error) bool {
+	var sdkErr *txerr.TencentCloudSDKError
+	if err == nil || !errors.As(err, &sdkErr) {
 		return false
 	}
-
-	set := make(map[string]struct{}, len(a))
-	for _, v := range a {
-		set[v] = struct{}{}
+	code := sdkErr.Code
+	switch {
+	case code == "UnauthorizedOperation",
+		strings.HasPrefix(code, "UnauthorizedOperation."),
+		strings.HasPrefix(code, "AuthFailure.UnauthorizedOperation"),
+		strings.Contains(code, "NoPermission"):
+		return true
 	}
-	for _, v := range b {
-		if _, ok := set[v]; !ok {
+	return false
+}
+
+// canonicalizeNames canonicalizes a domain slice exactly the way
+// domain.AsKey does — lowercase, trailing root dot trimmed, empties
+// dropped, deduplicated — and sorts the result so two sets can be
+// compared element-wise.
+func canonicalizeNames(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, v := range in {
+		v = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(v), "."))
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// isSameStrSetIgnoringNil reports whether a and b denote the same set of
+// domain names once canonicalized. Both sides are deduplicated first, so
+// duplicates on either side can no longer fake a match, and matching is
+// case-insensitive / root-dot-insensitive like the rest of the codebase.
+func isSameStrSetIgnoringNil(a, b []string) bool {
+	ca, cb := canonicalizeNames(a), canonicalizeNames(b)
+	if len(ca) != len(cb) {
+		return false
+	}
+	for i := range ca {
+		if ca[i] != cb[i] {
 			return false
 		}
 	}
@@ -46,4 +129,118 @@ func isSameStrSetRejectNilItemPtrArrPtrArr(a []*string, b []*string) bool {
 		return false
 	}
 	return isSameStrSetIgnoringNil(derefA, derefB)
+}
+
+// parseTxcTime parses a Tencent Cloud timestamp. It reports false for a
+// nil or unparsable value so callers can stay conservative instead of
+// treating an unknown expiry as "far in the future".
+func parseTxcTime(raw *string) (time.Time, bool) {
+	if raw == nil {
+		return time.Time{}, false
+	}
+	s := strings.TrimSpace(*raw)
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.ParseInLocation(txcTimeLayout, s, txcTimeZone); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// isTransientTxcError reports whether err is a Tencent Cloud failure
+// worth retrying. Throttling and server-side hiccups come back in well
+// under retry.Do's one-second fast-fail floor, so they need to be
+// recognized explicitly or the retry budget never engages.
+func isTransientTxcError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errTxcRetryable) {
+		return true
+	}
+
+	var sdkErr *txerr.TencentCloudSDKError
+	if !errors.As(err, &sdkErr) {
+		return false
+	}
+
+	code := sdkErr.Code
+	switch {
+	case strings.HasPrefix(code, "RequestLimitExceeded"),
+		strings.HasPrefix(code, "InternalError"),
+		strings.HasPrefix(code, "ClientError.NetworkError"),
+		strings.HasPrefix(code, "ClientError.HttpStatusCodeError"),
+		strings.Contains(code, "Throttling"):
+		return true
+	}
+	return false
+}
+
+// pickNewerUploadedCertificate returns the id of the newest stored
+// certificate that covers exactly domains, is not oldCertificateId, and
+// expires strictly after oldCertEnd.
+//
+// The expiry guard matters because the lookup runs with FilterExpiring=0
+// — the result set therefore contains expiring certificates too, and
+// without the guard a rebind could bind every resource to a certificate
+// staler than the one being replaced and then "confirm" that as success.
+// A zero oldCertEnd means the expiring certificate's own CertEndTime was
+// unparsable; the guard then degrades to "newest parsable match" rather
+// than refusing to rebind at all.
+func pickNewerUploadedCertificate(certificates []*txssl.Certificates, domains []string,
+	oldCertificateId string, oldCertEnd time.Time) (string, error) {
+	var (
+		newestId  string
+		newestEnd time.Time
+	)
+	for _, c := range certificates {
+		if c == nil || c.CertificateId == nil {
+			continue
+		}
+		if *c.CertificateId == oldCertificateId {
+			continue
+		}
+		if !isSameStrSetRejectNilItem(c.CertSANs, domains) {
+			continue
+		}
+		end, ok := parseTxcTime(c.CertEndTime)
+		if !ok {
+			continue
+		}
+		if !oldCertEnd.IsZero() && !end.After(oldCertEnd) {
+			continue
+		}
+		if newestId == "" || end.After(newestEnd) {
+			newestId, newestEnd = *c.CertificateId, end
+		}
+	}
+	if newestId == "" {
+		return "", fmt.Errorf("no stored certificate matches domains %v and expires after %s",
+			domains, oldCertEnd.Format(time.RFC3339))
+	}
+	return newestId, nil
+}
+
+// deployRecordListsResources reports whether a host-update record detail
+// response mentions at least one resource. TotalCount alone was not
+// enough: the SDK documents it as "0 if unavailable", so a response that
+// lists resources in RecordDetailList but omits the count used to read
+// as "no resource yet" and the poll waited out its whole timeout before
+// declaring success without ever confirming anything.
+func deployRecordListsResources(detail *txssl.DescribeHostUpdateRecordDetailResponseParams) bool {
+	if detail == nil {
+		return false
+	}
+	return int64OrZero(detail.TotalCount) > 0 || len(detail.RecordDetailList) > 0
+}
+
+func int64OrZero(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+	return *v
 }

--- a/exec/tools/tasks/txcCertificateUpdater/util_test.go
+++ b/exec/tools/tasks/txcCertificateUpdater/util_test.go
@@ -1,9 +1,23 @@
 package txcCertificateUpdater
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	txerr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	txssl "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ssl/v20191205"
+)
 
 func ptr(s string) *string {
 	return &s
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
 }
 
 func TestIsSameStrSetRejectNilItem(t *testing.T) {
@@ -27,5 +41,374 @@ func TestIsSameStrSetRejectNilItemPtrArrPtrArr(t *testing.T) {
 	}
 	if isSameStrSetRejectNilItemPtrArrPtrArr([]*string{ptr("a"), ptr("b")}, []*string{ptr("a"), nil}) {
 		t.Fatal("expected nil item to reject")
+	}
+}
+
+func TestIsSameStrSetIgnoringNilCanonicalizes(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []string
+		same bool
+	}{
+		{"duplicates in b no longer fake a match", []string{"a.example.com", "b.example.com"},
+			[]string{"a.example.com", "a.example.com"}, false},
+		{"duplicates on both sides collapse", []string{"a.example.com", "a.example.com", "b.example.com"},
+			[]string{"b.example.com", "a.example.com"}, true},
+		{"case insensitive", []string{"A.Example.COM"}, []string{"a.example.com"}, true},
+		{"trailing root dot ignored", []string{"a.example.com."}, []string{"a.example.com"}, true},
+		{"still detects a real difference", []string{"a.example.com"}, []string{"b.example.com"}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isSameStrSetIgnoringNil(c.a, c.b); got != c.same {
+				t.Fatalf("isSameStrSetIgnoringNil(%v, %v) = %v, want %v", c.a, c.b, got, c.same)
+			}
+			if got := isSameStrSetIgnoringNil(c.b, c.a); got != c.same {
+				t.Fatalf("isSameStrSetIgnoringNil(%v, %v) = %v, want %v (reversed)", c.b, c.a, got, c.same)
+			}
+		})
+	}
+}
+
+func TestParseTxcTime(t *testing.T) {
+	if _, ok := parseTxcTime(nil); ok {
+		t.Fatal("expected nil timestamp to be rejected")
+	}
+	if _, ok := parseTxcTime(ptr("not a time")); ok {
+		t.Fatal("expected garbage timestamp to be rejected")
+	}
+	early, ok := parseTxcTime(ptr("2026-01-02 03:04:05"))
+	if !ok {
+		t.Fatal("expected tencent cloud layout to parse")
+	}
+	late, ok := parseTxcTime(ptr("2026-02-02T03:04:05Z"))
+	if !ok {
+		t.Fatal("expected RFC3339 layout to parse")
+	}
+	if !late.After(early) {
+		t.Fatal("expected the later timestamp to compare later")
+	}
+}
+
+// TestParseTxcTimeUsesBeijingZone locks the zone of the zone-less
+// layout: Tencent Cloud reports Beijing time, so parsing it as UTC made
+// it compare eight hours off against RFC3339 values carrying an offset.
+func TestParseTxcTimeUsesBeijingZone(t *testing.T) {
+	got, ok := parseTxcTime(ptr("2026-01-02 03:04:05"))
+	if !ok {
+		t.Fatal("expected tencent cloud layout to parse")
+	}
+	want := time.Date(2026, 1, 2, 3, 4, 5, 0, time.FixedZone("CST", 8*60*60))
+	if !got.Equal(want) {
+		t.Fatalf("parseTxcTime = %s, want %s", got, want)
+	}
+
+	// The same instant spelled in both layouts must compare equal, and
+	// the UTC spelling of a *later* wall clock in Beijing must not.
+	same, ok := parseTxcTime(ptr("2026-01-02T03:04:05+08:00"))
+	if !ok {
+		t.Fatal("expected RFC3339 layout to parse")
+	}
+	if !got.Equal(same) {
+		t.Fatalf("mixed layouts disagree: %s != %s", got, same)
+	}
+	utcSpelling, ok := parseTxcTime(ptr("2026-01-02T03:04:05Z"))
+	if !ok {
+		t.Fatal("expected RFC3339 UTC layout to parse")
+	}
+	if !utcSpelling.After(got) {
+		t.Fatalf("expected 03:04:05Z to be after 03:04:05 Beijing, got %s vs %s", utcSpelling, got)
+	}
+}
+
+func TestPickNewerUploadedCertificate(t *testing.T) {
+	domains := []string{"example.com", "www.example.com"}
+	oldEnd, ok := parseTxcTime(ptr("2026-09-01 00:00:00"))
+	if !ok {
+		t.Fatal("failed to parse the fixture expiry")
+	}
+
+	stale := cert("stale", "2026-08-01 00:00:00", "www.example.com", "example.com")
+	sameDay := cert("same", "2026-09-01 00:00:00", "example.com", "www.example.com")
+	renewed := cert("renewed", "2026-12-01 00:00:00", "example.com", "www.example.com")
+	newest := cert("newest", "2027-01-01 00:00:00", "www.example.com", "example.com")
+	otherDomains := cert("other", "2027-06-01 00:00:00", "other.example.com")
+	unparsable := cert("broken", "unknown", "example.com", "www.example.com")
+	old := cert("old", "2026-09-01 00:00:00", "example.com", "www.example.com")
+
+	t.Run("stale and equal-expiry candidates are rejected", func(t *testing.T) {
+		for _, candidates := range [][]*txssl.Certificates{
+			{old, stale},
+			{old, sameDay},
+			{old, unparsable},
+			{old, otherDomains},
+			{old},
+		} {
+			got, err := pickNewerUploadedCertificate(candidates, domains, "old", oldEnd)
+			if err == nil {
+				t.Fatalf("expected no match, got %q", got)
+			}
+			if !strings.Contains(err.Error(), "no stored certificate matches") {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		}
+	})
+
+	t.Run("newest strictly newer candidate wins", func(t *testing.T) {
+		got, err := pickNewerUploadedCertificate(
+			[]*txssl.Certificates{old, stale, sameDay, renewed, newest, otherDomains, unparsable, nil},
+			domains, "old", oldEnd)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got != "newest" {
+			t.Fatalf("picked %q, want \"newest\"", got)
+		}
+	})
+
+	t.Run("unknown old expiry degrades to newest match", func(t *testing.T) {
+		got, err := pickNewerUploadedCertificate([]*txssl.Certificates{old, stale}, domains, "old", time.Time{})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got != "stale" {
+			t.Fatalf("picked %q, want \"stale\"", got)
+		}
+	})
+}
+
+func TestDeployRecordListsResources(t *testing.T) {
+	if deployRecordListsResources(nil) {
+		t.Fatal("expected a nil detail to list no resource")
+	}
+	empty := &txssl.DescribeHostUpdateRecordDetailResponseParams{}
+	if deployRecordListsResources(empty) {
+		t.Fatal("expected an empty detail to list no resource")
+	}
+	// TotalCount is documented as "0 if unavailable": a populated
+	// RecordDetailList alone must still count as resources seen.
+	listOnly := &txssl.DescribeHostUpdateRecordDetailResponseParams{
+		RecordDetailList: []*txssl.UpdateRecordDetails{{}},
+	}
+	if !deployRecordListsResources(listOnly) {
+		t.Fatal("expected a populated RecordDetailList to count as resources seen")
+	}
+	countOnly := &txssl.DescribeHostUpdateRecordDetailResponseParams{TotalCount: int64Ptr(2)}
+	if !deployRecordListsResources(countOnly) {
+		t.Fatal("expected a positive TotalCount to count as resources seen")
+	}
+}
+
+func TestIsTxcPermissionError(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{fmt.Errorf("plain"), false},
+		{txerr.NewTencentCloudSDKError("UnauthorizedOperation", "", "req"), true},
+		{fmt.Errorf("wrapped: %w", txerr.NewTencentCloudSDKError("UnauthorizedOperation.CamNoAuth", "", "req")), true},
+		{txerr.NewTencentCloudSDKError("AuthFailure.UnauthorizedOperation", "", "req"), true},
+		{txerr.NewTencentCloudSDKError("AuthFailure.SecretIdNotFound", "", "req"), false},
+		{txerr.NewTencentCloudSDKError("InternalError", "", "req"), false},
+	}
+	for _, c := range cases {
+		if got := isTxcPermissionError(c.err); got != c.want {
+			t.Fatalf("isTxcPermissionError(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+func cert(id, end string, sans ...string) *txssl.Certificates {
+	c := &txssl.Certificates{
+		CertificateId: ptr(id),
+		CertEndTime:   ptr(end),
+	}
+	for _, s := range sans {
+		c.CertSANs = append(c.CertSANs, ptr(s))
+	}
+	return c
+}
+
+func TestFindReplacementCertificate(t *testing.T) {
+	expiringA := cert("a", "2026-09-01 00:00:00", "example.com", "www.example.com")
+	expiringB := cert("b", "2026-09-02 00:00:00", "www.example.com", "example.com")
+	renewed := cert("c", "2026-12-01 00:00:00", "example.com", "www.example.com")
+	other := cert("d", "2027-01-01 00:00:00", "other.example.com")
+
+	expiringIds := map[string]struct{}{"a": {}, "b": {}}
+	activating := []*txssl.Certificates{expiringA, expiringB, other}
+
+	// Two same-SAN expiring certs must not suppress each other.
+	for _, c := range []*txssl.Certificates{expiringA, expiringB} {
+		got, err := findReplacementCertificate(activating, c, expiringIds)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got != nil {
+			t.Fatalf("cert %s: expected no replacement, got %s", *c.CertificateId, *got.CertificateId)
+		}
+	}
+
+	// A genuinely newer, non-expiring cert is a replacement.
+	got, err := findReplacementCertificate(append(activating, renewed), expiringA, expiringIds)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got == nil || *got.CertificateId != "c" {
+		t.Fatalf("expected cert c as replacement, got %v", got)
+	}
+
+	// An earlier-expiring same-SAN cert outside the expiring window is
+	// not a replacement either.
+	older := cert("e", "2026-08-01 00:00:00", "example.com", "www.example.com")
+	got, err = findReplacementCertificate([]*txssl.Certificates{older}, expiringA, expiringIds)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no replacement for an older cert, got %s", *got.CertificateId)
+	}
+
+	// An unparsable expiry never suppresses a renewal.
+	broken := cert("f", "unknown", "example.com", "www.example.com")
+	got, err = findReplacementCertificate([]*txssl.Certificates{broken}, expiringA, expiringIds)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no replacement for an unparsable cert end time, got %s", *got.CertificateId)
+	}
+}
+
+func TestIsTransientTxcError(t *testing.T) {
+	cases := []struct {
+		err       error
+		transient bool
+	}{
+		{nil, false},
+		{fmt.Errorf("plain"), false},
+		{txerr.NewTencentCloudSDKError("RequestLimitExceeded", "", "req"), true},
+		{fmt.Errorf("wrapped: %w", txerr.NewTencentCloudSDKError("InternalError.BackendError", "", "req")), true},
+		{txerr.NewTencentCloudSDKError("ClientError.HttpStatusCodeError", "503", "req"), true},
+		{txerr.NewTencentCloudSDKError("RequestLimitExceeded.GlobalThrottling", "", "req"), true},
+		{txerr.NewTencentCloudSDKError("FailedOperation.CertificateExists", "", "req"), false},
+		{txerr.NewTencentCloudSDKError("AuthFailure.SecretIdNotFound", "", "req"), false},
+		{fmt.Errorf("%w: no deploy record", errTxcRetryable), true},
+	}
+
+	for _, c := range cases {
+		if got := isTransientTxcError(c.err); got != c.transient {
+			t.Fatalf("isTransientTxcError(%v) = %v, want %v", c.err, got, c.transient)
+		}
+	}
+}
+
+func TestCallTxcAPIRetriesTransientFastFailures(t *testing.T) {
+	r := &TencentCloudCertificateUpdater{ctx: context.Background()}
+
+	// A throttling error returns in well under a second: it must reach
+	// the retry budget instead of the fast-fail path.
+	calls := 0
+	err := r.callTxcAPI(0, "DescribeCertificates", func() error {
+		calls++
+		return txerr.NewTencentCloudSDKError("RequestLimitExceeded", "", "req")
+	})
+	if err == nil || strings.Contains(err.Error(), "errored too fast") {
+		t.Fatalf("expected a retry-budget failure for a transient error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call with retryCount 0, got %d", calls)
+	}
+
+	// A deterministic fast failure still bails out immediately.
+	calls = 0
+	err = r.callTxcAPI(2, "DescribeCertificates", func() error {
+		calls++
+		return txerr.NewTencentCloudSDKError("AuthFailure.SecretIdNotFound", "", "req")
+	})
+	if err == nil || !strings.Contains(err.Error(), "errored too fast") {
+		t.Fatalf("expected fast-fail for a deterministic error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call for a fast deterministic failure, got %d", calls)
+	}
+
+	// Success short-circuits.
+	calls = 0
+	if err := r.callTxcAPI(2, "DescribeCertificates", func() error {
+		calls++
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call on success, got %d", calls)
+	}
+}
+
+// TestCallTxcAPIDoesNotRetryTerminalErrors locks the fix for the
+// storm-retry regression: a confirmed deploy failure surfaces after the
+// fast-fail window (the poll runs for tens of seconds), so only the
+// terminal marker keeps the whole upload + deploy from being replayed.
+func TestCallTxcAPIDoesNotRetryTerminalErrors(t *testing.T) {
+	r := &TencentCloudCertificateUpdater{ctx: context.Background()}
+
+	calls := 0
+	err := r.callTxcAPI(updateRetryCount, "UpdateCertificateInstance", func() error {
+		calls++
+		// Outlive the fast-fail floor the way a real deploy poll does.
+		time.Sleep(txcFastFailThreshold + 50*time.Millisecond)
+		return fmt.Errorf("%w: deploy record 42 for cert %q: 2 resource(s) failed to update", errTxcTerminal, "cert")
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, errTxcTerminal) {
+		t.Fatalf("expected the terminal marker to survive wrapping, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "resource(s) failed to update") {
+		t.Fatalf("expected the underlying verdict in the message, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected a terminal failure to run once, got %d calls", calls)
+	}
+	if isTransientTxcError(err) {
+		t.Fatal("a terminal failure must never be classified transient")
+	}
+}
+
+// TestWaitReplaceTaskDeadlineReportsTaskErrors locks the second half of
+// the reporting fix: the deadline branch must name the certificate that
+// failed instead of returning a bare context error.
+func TestWaitReplaceTaskDeadlineReportsTaskErrors(t *testing.T) {
+	r := &TencentCloudCertificateUpdater{}
+	r.wg.Add(1) // a handler that never finishes
+	r.taskErr = append(r.taskErr, fmt.Errorf("replace cert %q: deploy failed", "web"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.WaitReplaceTask(ctx)
+	if err == nil {
+		t.Fatal("expected an error when the deadline fires")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the context error to be reported, got %v", err)
+	}
+	if !strings.Contains(err.Error(), `replace cert "web"`) {
+		t.Fatalf("expected the failing cert to be named, got %v", err)
+	}
+}
+
+func TestWaitDeployRecordMissingRecordIsRetryable(t *testing.T) {
+	r := &TencentCloudCertificateUpdater{ctx: context.Background()}
+
+	for _, id := range []*uint64{nil, new(uint64)} {
+		err := r.waitDeployRecord("cert", id)
+		if err == nil || !isTransientTxcError(err) {
+			t.Fatalf("expected a retryable error for deploy record %v, got %v", id, err)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/go-acme/lego/v4 v4.35.2
 	google.golang.org/api v0.288.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260715232425-e75dac1f907d
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )
@@ -65,5 +66,4 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260715232425-e75dac1f907d // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260715232425-e75dac1f907d // indirect
 )

--- a/pkg/acme/challenge.go
+++ b/pkg/acme/challenge.go
@@ -11,6 +11,7 @@ import (
 	"pkg.para.party/certdx/pkg/acme/challengeproviders/s3"
 	"pkg.para.party/certdx/pkg/acme/challengeproviders/tencentcloud"
 	"pkg.para.party/certdx/pkg/config"
+	"pkg.para.party/certdx/pkg/logging"
 )
 
 func SetChallenger(legoCfg *lego.Config, instance *ACME, p *config.ServerConfig) error {
@@ -20,24 +21,9 @@ func SetChallenger(legoCfg *lego.Config, instance *ACME, p *config.ServerConfig)
 	}
 	switch typ {
 	case config.ChallengeTypeDns01:
-		opt := make([]dns01.ChallengeOption, 0)
-
-		if p.DnsProvider.DisableCompletePropagationRequirement {
-			opt = append(opt, dns01.DisableAuthoritativeNssPropagationRequirement())
-		}
-
-		// 添加自定义 DNS 服务器
-		if len(p.DnsProvider.Nameservers) > 0 {
-			opt = append(opt, dns01.AddRecursiveNameservers(p.DnsProvider.Nameservers))
-		}
-
-		// 添加 DNS 超时
-		if p.DnsProvider.DNSTimeout != "" {
-			timeout, err := time.ParseDuration(p.DnsProvider.DNSTimeout)
-			if err != nil {
-				return fmt.Errorf("invalid dnsTimeout %q: %w", p.DnsProvider.DNSTimeout, err)
-			}
-			opt = append(opt, dns01.AddDNSTimeout(timeout))
+		opt, err := dns01Options(p.DnsProvider)
+		if err != nil {
+			return err
 		}
 
 		if err := instance.Client.Challenge.SetDNS01Provider(clg, opt...); err != nil {
@@ -52,6 +38,48 @@ func SetChallenger(legoCfg *lego.Config, instance *ACME, p *config.ServerConfig)
 	}
 
 	return nil
+}
+
+// dns01Options translates the [DnsProvider] config block into lego
+// challenge options.
+//
+// Note on nameservers: lego only uses the recursive resolvers for zone /
+// CNAME discovery, the TXT value itself is verified against the
+// authoritative nameservers. So once the authoritative requirement is
+// disabled, no TXT verification happens at all — the configured resolvers
+// are never asked for the record. RecursiveNSsPropagationRequirement puts
+// the verification back on them. With the authoritative check still on the
+// record is already verified, so requiring it twice would only slow
+// issuance down.
+func dns01Options(p *config.DnsProvider) ([]dns01.ChallengeOption, error) {
+	opt := make([]dns01.ChallengeOption, 0)
+
+	if p.DisableCompletePropagationRequirement {
+		opt = append(opt, dns01.DisableAuthoritativeNssPropagationRequirement())
+		if len(p.Nameservers) == 0 {
+			logging.Warn("DnsProvider: disableCompletePropagationRequirement is set without nameservers, " +
+				"the TXT record is not verified at all before the CA is asked to validate")
+		}
+	}
+
+	// 添加自定义 DNS 服务器
+	if len(p.Nameservers) > 0 {
+		opt = append(opt, dns01.AddRecursiveNameservers(p.Nameservers))
+		if p.DisableCompletePropagationRequirement {
+			opt = append(opt, dns01.RecursiveNSsPropagationRequirement())
+		}
+	}
+
+	// 添加 DNS 超时
+	if p.DNSTimeout != "" {
+		timeout, err := time.ParseDuration(p.DNSTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dnsTimeout %q: %w", p.DNSTimeout, err)
+		}
+		opt = append(opt, dns01.AddDNSTimeout(timeout))
+	}
+
+	return opt, nil
 }
 
 func getChallenger(legoCfg *lego.Config, p *config.ServerConfig) (string, challenge.Provider, error) {

--- a/pkg/acme/challenge_test.go
+++ b/pkg/acme/challenge_test.go
@@ -1,0 +1,88 @@
+package acme
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-acme/lego/v4/challenge/dns01"
+	"pkg.para.party/certdx/pkg/config"
+)
+
+// preCheckFlags applies the options to a throw-away lego challenge and
+// reports the two propagation requirements it ended up with. The fields
+// are unexported, but reflect can read booleans out of them without
+// going through Interface().
+func preCheckFlags(t *testing.T, opts []dns01.ChallengeOption) (authoritative, recursive bool) {
+	t.Helper()
+	chlg := dns01.NewChallenge(nil, nil, nil, opts...)
+	preCheck := reflect.ValueOf(chlg).Elem().FieldByName("preCheck")
+	if !preCheck.IsValid() {
+		t.Fatal("dns01.Challenge has no preCheck field, lego internals changed")
+	}
+	return preCheck.FieldByName("requireAuthoritativeNssPropagation").Bool(),
+		preCheck.FieldByName("requireRecursiveNssPropagation").Bool()
+}
+
+func TestDns01OptionsPropagationRequirements(t *testing.T) {
+	cases := []struct {
+		name              string
+		provider          config.DnsProvider
+		wantAuthoritative bool
+		wantRecursive     bool
+	}{
+		{
+			name:              "defaults keep authoritative check",
+			provider:          config.DnsProvider{},
+			wantAuthoritative: true,
+			wantRecursive:     false,
+		},
+		{
+			name:              "nameservers alone do not add recursive check",
+			provider:          config.DnsProvider{Nameservers: []string{"1.1.1.1"}},
+			wantAuthoritative: true,
+			wantRecursive:     false,
+		},
+		{
+			name: "disabled authoritative check without nameservers",
+			provider: config.DnsProvider{
+				DisableCompletePropagationRequirement: true,
+			},
+			wantAuthoritative: false,
+			wantRecursive:     false,
+		},
+		{
+			// The regression: disabling the authoritative requirement while
+			// pointing lego at custom resolvers used to verify nothing at all.
+			name: "disabled authoritative check with nameservers verifies on the resolvers",
+			provider: config.DnsProvider{
+				DisableCompletePropagationRequirement: true,
+				Nameservers:                           []string{"1.1.1.1", "8.8.8.8:53"},
+			},
+			wantAuthoritative: false,
+			wantRecursive:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := dns01Options(&tc.provider)
+			if err != nil {
+				t.Fatalf("dns01Options: %v", err)
+			}
+			authoritative, recursive := preCheckFlags(t, opts)
+			if authoritative != tc.wantAuthoritative {
+				t.Errorf("requireAuthoritativeNssPropagation=%v want %v", authoritative, tc.wantAuthoritative)
+			}
+			if recursive != tc.wantRecursive {
+				t.Errorf("requireRecursiveNssPropagation=%v want %v", recursive, tc.wantRecursive)
+			}
+		})
+	}
+}
+
+func TestDns01OptionsRejectsBadTimeout(t *testing.T) {
+	_, err := dns01Options(&config.DnsProvider{DNSTimeout: "not a duration"})
+	if err == nil {
+		t.Fatal("expected an error for an unparseable dnsTimeout")
+	}
+}

--- a/pkg/acme/challengeproviders/s3/s3.go
+++ b/pkg/acme/challengeproviders/s3/s3.go
@@ -6,18 +6,30 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/go-acme/lego/v4/challenge/http01"
 	"pkg.para.party/certdx/pkg/config"
 )
 
+// requestTimeout bounds a single S3 API call. lego gives the provider no
+// context, so Present/CleanUp derive their own rather than blocking the
+// whole challenge on a wedged connection.
+const requestTimeout = 30 * time.Second
+
 // HTTPProvider implements ChallengeProvider for `http-01` challenge.
 type HTTPProvider struct {
 	bucket string
+	// acl is the canned ACL applied to the challenge object, already
+	// resolved from the config by [config.S3Client.ResolvedACL]. Empty means
+	// no ACL header is sent, which is the only thing that works on buckets
+	// with ACLs disabled (the default for buckets created since Apr 2023).
+	acl    types.ObjectCannedACL
 	client *s3.Client
 }
 
@@ -28,7 +40,10 @@ func (s *HTTPProvider) Client() *s3.Client {
 // NewHTTPProvider returns a HTTPProvider instance with a configured s3 bucket and aws session.
 // Credentials must be passed in the environment variables. The bucket name
 // is required; an empty bucket fails fast rather than producing opaque
-// runtime errors deep inside an ACME challenge.
+// runtime errors deep inside an ACME challenge. The canned ACL follows
+// cfg.ResolvedACL: unset means the historical "public-read", an explicit
+// empty acl sends no ACL header at all (for buckets with ACLs disabled,
+// where public read access comes from the bucket policy instead).
 func NewHTTPProvider(cfg config.S3Client) (*HTTPProvider, error) {
 	if cfg.Bucket == "" {
 		return nil, fmt.Errorf("s3 challenge provider: bucket is required")
@@ -55,6 +70,7 @@ func NewHTTPProvider(cfg config.S3Client) (*HTTPProvider, error) {
 
 	return &HTTPProvider{
 		bucket: cfg.Bucket,
+		acl:    types.ObjectCannedACL(cfg.ResolvedACL()),
 		client: s3.NewFromConfig(awsCfg, func(o *s3.Options) {
 			o.UsePathStyle = false
 		}),
@@ -63,13 +79,18 @@ func NewHTTPProvider(cfg config.S3Client) (*HTTPProvider, error) {
 
 // Present makes the token available at `HTTP01ChallengePath(token)` by creating a file in the given s3 bucket.
 func (s *HTTPProvider) Present(domain, token, keyAuth string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
 
 	params := &s3.PutObjectInput{
-		ACL:    "public-read",
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(strings.Trim(http01.ChallengePath(token), "/")),
 		Body:   bytes.NewReader([]byte(keyAuth)),
+	}
+	// An empty ACL must not put an x-amz-acl header on the wire: buckets with
+	// ACLs disabled reject the request outright.
+	if s.acl != "" {
+		params.ACL = s.acl
 	}
 
 	_, err := s.client.PutObject(ctx, params)
@@ -81,7 +102,8 @@ func (s *HTTPProvider) Present(domain, token, keyAuth string) error {
 
 // CleanUp removes the file created for the challenge.
 func (s *HTTPProvider) CleanUp(domain, token, keyAuth string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
 
 	params := &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),

--- a/pkg/acme/challengeproviders/s3/s3_internal_test.go
+++ b/pkg/acme/challengeproviders/s3/s3_internal_test.go
@@ -1,0 +1,128 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"pkg.para.party/certdx/pkg/config"
+)
+
+// testProvider wires a HTTPProvider at a local httptest server so the
+// request the SDK actually puts on the wire can be inspected.
+func testProvider(t *testing.T, acl types.ObjectCannedACL, endpoint string) *HTTPProvider {
+	t.Helper()
+
+	awsCfg, err := awsConfig.LoadDefaultConfig(
+		context.Background(),
+		awsConfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("id", "secret", "")),
+		awsConfig.WithRegion("auto"),
+	)
+	if err != nil {
+		t.Fatalf("load AWS config: %v", err)
+	}
+
+	return &HTTPProvider{
+		bucket: "bucket",
+		acl:    acl,
+		client: s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+			o.BaseEndpoint = &endpoint
+			// httptest has no wildcard DNS for virtual-host style.
+			o.UsePathStyle = true
+		}),
+	}
+}
+
+// TestNewHTTPProviderACL pins how the config's acl field lands on the
+// provider: unset keeps the "public-read" certdx <= v0.6.0 hardcoded, an
+// explicit empty acl opts out of the header for ACL-disabled buckets.
+func TestNewHTTPProviderACL(t *testing.T) {
+	empty := ""
+	private := "private"
+
+	cases := []struct {
+		name string
+		acl  *string
+		want types.ObjectCannedACL
+	}{
+		{"unset keeps public-read", nil, types.ObjectCannedACLPublicRead},
+		{"explicit empty sends no ACL", &empty, ""},
+		{"explicit value passed through", &private, types.ObjectCannedACLPrivate},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewHTTPProvider(config.S3Client{Bucket: "bucket", ACL: tc.acl})
+			if err != nil {
+				t.Fatalf("NewHTTPProvider: %v", err)
+			}
+			if p.acl != tc.want {
+				t.Errorf("acl = %q want %q", p.acl, tc.want)
+			}
+		})
+	}
+}
+
+// TestPresentACLHeader pins the S3 ACL behaviour on the wire: buckets created
+// since Apr 2023 have ACLs disabled and reject any x-amz-acl header, so an
+// empty resolved ACL must send no header at all.
+func TestPresentACLHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		acl    types.ObjectCannedACL
+		wantHd string
+	}{
+		{"empty ACL omits the header", "", ""},
+		{"resolved ACL is sent", types.ObjectCannedACLPublicRead, "public-read"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var seen bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen = true
+				got = r.Header.Get("X-Amz-Acl")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			p := testProvider(t, tc.acl, srv.URL)
+			if err := p.Present("example.com", "token", "keyAuth"); err != nil {
+				t.Fatalf("Present: %v", err)
+			}
+			if !seen {
+				t.Fatal("no request reached the test server")
+			}
+			if got != tc.wantHd {
+				t.Errorf("X-Amz-Acl=%q want %q", got, tc.wantHd)
+			}
+		})
+	}
+}
+
+// TestCleanUpDeletes checks CleanUp issues the DELETE for the challenge
+// path and does not hang on its own context.
+func TestCleanUpDeletes(t *testing.T) {
+	var method, path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := testProvider(t, "", srv.URL)
+	if err := p.CleanUp("example.com", "token", "keyAuth"); err != nil {
+		t.Fatalf("CleanUp: %v", err)
+	}
+	if method != http.MethodDelete {
+		t.Errorf("method=%s want DELETE", method)
+	}
+	if want := "/bucket/.well-known/acme-challenge/token"; path != want {
+		t.Errorf("path=%s want %s", path, want)
+	}
+}

--- a/pkg/acme/user.go
+++ b/pkg/acme/user.go
@@ -17,6 +17,7 @@ import (
 	"pkg.para.party/certdx/pkg/acme/acmeproviders"
 	"pkg.para.party/certdx/pkg/acme/acmeproviders/google"
 	"pkg.para.party/certdx/pkg/config"
+	"pkg.para.party/certdx/pkg/logging"
 	"pkg.para.party/certdx/pkg/paths"
 )
 
@@ -65,7 +66,7 @@ func makeACMEUser(c *config.ServerConfig) (*ACMEUser, error) {
 			hmac = account.HmacEncoded
 		}
 
-		if err := RegisterAccount(c.ACME.Provider, c.ACME.Email, kid, hmac); err != nil {
+		if err := RegisterAccount(c.ACME.Provider, c.ACME.Email, kid, hmac, false); err != nil {
 			return nil, err
 		}
 	} else if err != nil {
@@ -101,10 +102,37 @@ func makeACMEUser(c *config.ServerConfig) (*ACMEUser, error) {
 	return user, nil
 }
 
-func RegisterAccount(ACMEProvider, Email, Kid, Hmac string) error {
+// RegisterAccount registers a fresh ACME account and stores its private
+// key under the state root. The account key is the only proof of account
+// ownership certdx keeps, so an existing key is never replaced unless
+// force is set; when force is set the previous key is restored if the
+// registration fails half way through.
+func RegisterAccount(ACMEProvider, Email, Kid, Hmac string, force bool) error {
 	keyPath, err := paths.ACMEPrivateKey(Email, ACMEProvider)
 	if err != nil {
 		return err
+	}
+
+	previousKey, err := os.ReadFile(keyPath)
+	switch {
+	case err == nil && !force:
+		return fmt.Errorf("ACME account key %s already exists, refusing to overwrite it "+
+			"(re-run with force to replace the account key)", keyPath)
+	case err != nil && !os.IsNotExist(err):
+		return fmt.Errorf("read existing ACME account key: %w", err)
+	}
+	hadPreviousKey := err == nil
+
+	// restoreKey undoes the key file write on any failure path: either put
+	// the pre-existing key back, or remove the one we just created.
+	restoreKey := func() {
+		if hadPreviousKey {
+			if err := os.WriteFile(keyPath, previousKey, 0o600); err != nil {
+				logging.Error("failed restoring previous ACME account key %s: %v", keyPath, err)
+			}
+			return
+		}
+		os.Remove(keyPath)
 	}
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
@@ -118,7 +146,12 @@ func RegisterAccount(ACMEProvider, Email, Kid, Hmac string) error {
 	}
 	pemEncoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509Encoded})
 
+	if hadPreviousKey {
+		logging.Warn("overwriting existing ACME account key %s, the previous account "+
+			"will no longer be usable through certdx", keyPath)
+	}
 	if err := os.WriteFile(keyPath, pemEncoded, 0o600); err != nil {
+		restoreKey()
 		return fmt.Errorf("save ACME account key: %w", err)
 	}
 
@@ -132,7 +165,7 @@ func RegisterAccount(ACMEProvider, Email, Kid, Hmac string) error {
 
 	client, err := lego.NewClient(config)
 	if err != nil {
-		os.Remove(keyPath)
+		restoreKey()
 		return fmt.Errorf("failed constructing acme client: %w", err)
 	}
 
@@ -150,13 +183,13 @@ func RegisterAccount(ACMEProvider, Email, Kid, Hmac string) error {
 		myUser.Registration, err = client.Registration.Register(regOptions)
 	}
 	if err != nil {
-		os.Remove(keyPath)
+		restoreKey()
 		return fmt.Errorf("failed to register: %w", err)
 	}
 
 	reg, err := json.Marshal(myUser.Registration)
 	if err != nil {
-		os.Remove(keyPath)
+		restoreKey()
 		return fmt.Errorf("failed marshaling registration: %w", err)
 	}
 

--- a/pkg/acme/user_test.go
+++ b/pkg/acme/user_test.go
@@ -6,7 +6,11 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"os"
 	"testing"
+
+	"pkg.para.party/certdx/pkg/acme/acmeproviders"
+	"pkg.para.party/certdx/pkg/paths"
 )
 
 // TestParsePEMRoundTrip generates an ECDSA P-384 key (the same curve
@@ -57,5 +61,81 @@ func TestParsePEMRejectsInvalid(t *testing.T) {
 				t.Fatal("expected error on invalid input")
 			}
 		})
+	}
+}
+
+// accountKeyPath points the state root at a temp dir and returns the
+// account key path RegisterAccount would use for the mock provider. The
+// mock provider has an empty directory URL, so lego fails to build a
+// client without touching the network — which is exactly the failure
+// path the key handling has to survive.
+func accountKeyPath(t *testing.T) string {
+	t.Helper()
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	keyPath, err := paths.ACMEPrivateKey("u@example.com", acmeproviders.Mock)
+	if err != nil {
+		t.Fatalf("ACMEPrivateKey: %v", err)
+	}
+	return keyPath
+}
+
+// TestRegisterAccountKeepsExistingKey pins the data-loss fix: without
+// force, an existing account key is never touched.
+func TestRegisterAccountKeepsExistingKey(t *testing.T) {
+	keyPath := accountKeyPath(t)
+	existing := []byte("existing account key")
+	if err := os.WriteFile(keyPath, existing, 0o600); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	if err := RegisterAccount(acmeproviders.Mock, "u@example.com", "", "", false); err == nil {
+		t.Fatal("expected RegisterAccount to refuse overwriting an existing key")
+	}
+
+	got, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if string(got) != string(existing) {
+		t.Fatalf("account key was modified: %q", got)
+	}
+}
+
+// TestRegisterAccountForceRestoresKey checks that a forced re-register
+// that fails puts the previous key back instead of leaving the account
+// unrecoverable.
+func TestRegisterAccountForceRestoresKey(t *testing.T) {
+	keyPath := accountKeyPath(t)
+	existing := []byte("existing account key")
+	if err := os.WriteFile(keyPath, existing, 0o600); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	if err := RegisterAccount(acmeproviders.Mock, "u@example.com", "", "", true); err == nil {
+		t.Fatal("expected RegisterAccount to fail against the mock directory")
+	}
+
+	got, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if string(got) != string(existing) {
+		t.Fatalf("previous account key was not restored: %q", got)
+	}
+}
+
+// TestRegisterAccountCleansUpNewKey keeps the old behaviour for the case
+// there was nothing to lose: a failed first registration leaves no key.
+func TestRegisterAccountCleansUpNewKey(t *testing.T) {
+	keyPath := accountKeyPath(t)
+
+	if err := RegisterAccount(acmeproviders.Mock, "u@example.com", "", "", false); err == nil {
+		t.Fatal("expected RegisterAccount to fail against the mock directory")
+	}
+
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("stat %s: want not exist, got %v", keyPath, err)
 	}
 }

--- a/pkg/client/daemon.go
+++ b/pkg/client/daemon.go
@@ -40,6 +40,14 @@ type CertDXClientDaemon struct {
 	certs map[domain.Key]*watchingCert
 	wg    sync.WaitGroup
 
+	// httpClients caches the config-derived CertDXHttpClient per server.
+	// The clients are immutable once built, so every poll round reuses
+	// the same transport instead of leaking one idle TLS connection pool
+	// per attempt. Guarded by httpClientsMu — one poller goroutine runs
+	// per watched cert.
+	httpClientsMu sync.Mutex
+	httpClients   map[*config.ClientHttpServer]*CertDXHttpClient
+
 	// rootCtx is the lifecycle parent for every daemon subgoroutine
 	// (watchers, pollers, the gRPC failover state machine). Stop cancels
 	// it exactly once via stopOnce. There is no separate stop chan —
@@ -108,14 +116,36 @@ func (r *CertDXClientDaemon) watchUpdate(c *watchingCert) {
 func MakeCertDXClientDaemon() *CertDXClientDaemon {
 	rootCtx, rootCancel := context.WithCancel(context.Background())
 	ret := &CertDXClientDaemon{
-		Config:     &config.ClientConfig{},
-		ClientOpt:  make([]CertDXHttpClientOption, 0),
-		certs:      make(map[domain.Key]*watchingCert),
-		rootCtx:    rootCtx,
-		rootCancel: rootCancel,
+		Config:      &config.ClientConfig{},
+		ClientOpt:   make([]CertDXHttpClientOption, 0),
+		certs:       make(map[domain.Key]*watchingCert),
+		httpClients: make(map[*config.ClientHttpServer]*CertDXHttpClient),
+		rootCtx:     rootCtx,
+		rootCancel:  rootCancel,
 	}
 	ret.Config.SetDefault()
 	return ret
+}
+
+// httpClientFor returns the shared client for server, building it on
+// first use. A build failure (e.g. an unreadable mTLS bundle) is
+// returned as an ordinary — hence retryable — error; it must never take
+// the process down, since the same code runs inside the Caddy plugin
+// and certdx_tools.
+func (r *CertDXClientDaemon) httpClientFor(server *config.ClientHttpServer) (*CertDXHttpClient, error) {
+	r.httpClientsMu.Lock()
+	defer r.httpClientsMu.Unlock()
+
+	if c, ok := r.httpClients[server]; ok {
+		return c, nil
+	}
+
+	c, err := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(server))...)
+	if err != nil {
+		return nil, err
+	}
+	r.httpClients[server] = c
+	return c, nil
 }
 
 // loadSavedCert reads any previously-persisted cert/key for this
@@ -158,12 +188,21 @@ func (r *CertDXClientDaemon) ClientInit() {
 
 		cert := &watchingCert{
 			Config:         c,
-			UpdateHandlers: []CertificateUpdateHandler{writeCertAndDoCommand},
+			UpdateHandlers: []CertificateUpdateHandler{r.certWriteHandler()},
 			UpdateChan:     make(chan certData, 1),
 		}
 		cert.Data.Store(&cd)
 
 		r.certs[domain.AsKey(c.Domains)] = cert
+	}
+}
+
+// certWriteHandler binds the on-disk write/reload handler to the
+// daemon's root context, so the reload command dies with the daemon
+// instead of outliving it (or wedging the watcher goroutine).
+func (r *CertDXClientDaemon) certWriteHandler() CertificateUpdateHandler {
+	return func(fullchain, key []byte, c *config.ClientCertification) {
+		writeCertAndDoCommand(r.rootCtx, fullchain, key, c)
 	}
 }
 

--- a/pkg/client/daemon_test.go
+++ b/pkg/client/daemon_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"path/filepath"
 	"testing"
 
 	"pkg.para.party/certdx/pkg/config"
@@ -38,5 +39,47 @@ func TestAddCertToWatchOptKeepsHandlersForDuplicateDomains(t *testing.T) {
 
 	if firstCalls != 1 || secondCalls != 1 {
 		t.Fatalf("one certificate notification should reach both registrations; calls = first:%d second:%d", firstCalls, secondCalls)
+	}
+}
+
+// TestHttpClientForReusesClient pins the transport-leak fix: the
+// config-derived client is built once and reused by every poll round,
+// instead of a fresh http.Transport per attempt.
+func TestHttpClientForReusesClient(t *testing.T) {
+	d := MakeCertDXClientDaemon()
+	d.Config.Http.MainServer = config.ClientHttpServer{
+		Url:        "https://example.com",
+		AuthMethod: config.HTTP_AUTH_TOKEN,
+		Token:      "tok",
+	}
+
+	first, err := d.httpClientFor(&d.Config.Http.MainServer)
+	if err != nil {
+		t.Fatalf("httpClientFor: %v", err)
+	}
+	second, err := d.httpClientFor(&d.Config.Http.MainServer)
+	if err != nil {
+		t.Fatalf("httpClientFor: %v", err)
+	}
+	if first != second {
+		t.Fatal("httpClientFor built a second client for the same server")
+	}
+}
+
+// TestHttpClientForReturnsErrorOnBadMTLS: a broken mTLS bundle must be
+// a plain error, never a process exit.
+func TestHttpClientForReturnsErrorOnBadMTLS(t *testing.T) {
+	d := MakeCertDXClientDaemon()
+	d.Config.Http.MainServer = config.ClientHttpServer{
+		Url:              "https://example.com",
+		AuthMethod:       config.HTTP_AUTH_MTLS,
+		ClientMtlsConfig: config.ClientMtlsConfig{PEM: filepath.Join(t.TempDir(), "does-not-exist.pem")},
+	}
+
+	if _, err := d.httpClientFor(&d.Config.Http.MainServer); err == nil {
+		t.Fatal("expected error for unreadable mtls bundle")
+	}
+	if _, cached := d.httpClients[&d.Config.Http.MainServer]; cached {
+		t.Fatal("failed client must not be cached")
 	}
 }

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"pkg.para.party/certdx/pkg/config"
 	"pkg.para.party/certdx/pkg/logging"
@@ -17,6 +19,12 @@ const (
 	permCertFile os.FileMode = 0o644
 	permKeyFile  os.FileMode = 0o600
 )
+
+// reloadCommandTimeout bounds the reload command. The handler runs on
+// the sole UpdateChan consumer, so a reload that never returns would
+// drop every later update and hang Stop; killing it keeps the watcher
+// loop in control.
+const reloadCommandTimeout = 60 * time.Second
 
 // CertificateUpdateHandler is invoked whenever a watched cert receives
 // fresh material. Handlers are expected to be quick; long-running work
@@ -61,6 +69,16 @@ func prepareTempFile(dir, base string, data []byte, mode os.FileMode) (string, e
 		os.Remove(name)
 		return "", fmt.Errorf("chmod temp file: %w", err)
 	}
+	// Flush to stable storage before the rename: otherwise a crash can
+	// leave the rename durable but the contents not, i.e. a zero-length
+	// cert or key at the final path with no fallback.
+	//
+	// Best effort, exactly like syncDir: some FUSE and container mounts
+	// answer fsync with ENOSYS/ENOTSUP/EINVAL, and durability polish
+	// must never be what stops a certificate from being delivered.
+	if err := syncFile(tmp); err != nil {
+		logging.Warn("Failed to sync %s, continuing without fsync: %s", name, err)
+	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(name)
 		return "", fmt.Errorf("close temp file: %w", err)
@@ -94,7 +112,32 @@ func writeCertKeyPairAtomic(certPath string, fullchain []byte, keyPath string, k
 	if err := os.Rename(keyTmp, keyPath); err != nil {
 		return fmt.Errorf("rename key: %w", err)
 	}
+
+	// Persist the directory entries the renames created. Best effort:
+	// some filesystems/platforms refuse to fsync a directory, and that
+	// must not fail a write that already landed.
+	syncDir(filepath.Dir(certPath))
+	if keyDir := filepath.Dir(keyPath); keyDir != filepath.Dir(certPath) {
+		syncDir(keyDir)
+	}
 	return nil
+}
+
+// syncFile fsyncs f so its contents survive a crash. It is a var so
+// tests can simulate a mount that refuses fsync.
+var syncFile = func(f *os.File) error { return f.Sync() }
+
+// syncDir fsyncs dir so a preceding rename survives a crash.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		logging.Debug("Failed to open %s for sync: %s", dir, err)
+		return
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		logging.Debug("Failed to sync %s: %s", dir, err)
+	}
 }
 
 // writeCertAndDoCommand persists fullchain/key to the paths configured
@@ -104,8 +147,9 @@ func writeCertKeyPairAtomic(certPath string, fullchain []byte, keyPath string, k
 //
 // The reload command runs only when both files pre-existed; the first
 // install is effectively a bootstrap and the downstream service is
-// unlikely to be running yet.
-func writeCertAndDoCommand(fullchain, key []byte, c *config.ClientCertification) {
+// unlikely to be running yet. It is bounded by ctx and
+// reloadCommandTimeout, whichever fires first.
+func writeCertAndDoCommand(ctx context.Context, fullchain, key []byte, c *config.ClientCertification) {
 	var certExists, keyExists bool
 
 	certPath, keyPath, err := c.GetFullChainAndKeyPath()
@@ -129,18 +173,38 @@ func writeCertAndDoCommand(fullchain, key []byte, c *config.ClientCertification)
 	logging.Info("Saved cert %v", c.Domains)
 
 	if certExists && keyExists {
-		// strings.Fields collapses whitespace and skips empty inputs, so
-		// a whitespace-only ReloadCommand returns an empty slice — guard
-		// against args[0] panicking instead of just !=  "".
-		if args := strings.Fields(c.ReloadCommand); len(args) > 0 {
-			logging.Debug("Executing reload command: %s", c.ReloadCommand)
-			if err = exec.Command(args[0], args[1:]...).Run(); err != nil {
-				logging.Error("Failed executing reload command %s: %s", c.ReloadCommand, err)
-			}
-		}
+		runReloadCommand(ctx, c.ReloadCommand, reloadCommandTimeout)
 	}
 	return
 
 ERR:
 	logging.Error("Failed to save cert file: %s", err)
+}
+
+// runReloadCommand executes command, killing it after timeout (or when
+// ctx is cancelled). It always returns: the caller is the sole
+// UpdateChan consumer, so blocking here would stall every later cert
+// update and hang daemon shutdown.
+func runReloadCommand(ctx context.Context, command string, timeout time.Duration) {
+	// strings.Fields collapses whitespace and skips empty inputs, so
+	// a whitespace-only ReloadCommand returns an empty slice — guard
+	// against args[0] panicking instead of just !=  "".
+	args := strings.Fields(command)
+	if len(args) == 0 {
+		return
+	}
+
+	logging.Debug("Executing reload command: %s", command)
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err := exec.CommandContext(cmdCtx, args[0], args[1:]...).Run()
+	if err == nil {
+		return
+	}
+	if cmdCtx.Err() != nil {
+		logging.Error("Reload command %s did not finish within %s, killed: %s", command, timeout, err)
+	} else {
+		logging.Error("Failed executing reload command %s: %s", command, err)
+	}
 }

--- a/pkg/client/handler_test.go
+++ b/pkg/client/handler_test.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"pkg.para.party/certdx/pkg/config"
 )
@@ -117,6 +120,52 @@ func TestPrepareTempFileMissingDir(t *testing.T) {
 	}
 }
 
+// TestPrepareTempFileSurvivesFsyncFailure pins the best-effort fsync:
+// some FUSE/container mounts answer fsync with ENOSYS/EINVAL, and that
+// must not stop a certificate write that would otherwise land.
+func TestPrepareTempFileSurvivesFsyncFailure(t *testing.T) {
+	orig := syncFile
+	t.Cleanup(func() { syncFile = orig })
+	syncFile = func(*os.File) error { return syscall.ENOSYS }
+
+	root := t.TempDir()
+	p := filepath.Join(root, "cert.pem")
+	tmp, err := prepareTempFile(root, "cert.pem", []byte("CERT"), 0o600)
+	if err != nil {
+		t.Fatalf("fsync failure must not fail the write: %v", err)
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if got, err := os.ReadFile(p); err != nil || string(got) != "CERT" {
+		t.Fatalf("contents: got %q err %v", got, err)
+	}
+}
+
+// TestWriteCertAndDoCommandSurvivesFsyncFailure walks the same mount
+// through the full write path: a refused fsync must still deliver both
+// cert and key.
+func TestWriteCertAndDoCommandSurvivesFsyncFailure(t *testing.T) {
+	orig := syncFile
+	t.Cleanup(func() { syncFile = orig })
+	syncFile = func(*os.File) error { return syscall.EINVAL }
+
+	root := t.TempDir()
+	c := &config.ClientCertification{
+		Name:     "site",
+		SavePath: root,
+		Domains:  []string{"example.com"},
+	}
+	writeCertAndDoCommand(context.Background(), []byte("CERT"), []byte("KEY"), c)
+
+	if got, err := os.ReadFile(filepath.Join(root, "site.pem")); err != nil || string(got) != "CERT" {
+		t.Fatalf("cert not delivered on a mount that refuses fsync: got %q err %v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "site.key")); err != nil || string(got) != "KEY" {
+		t.Fatalf("key not delivered on a mount that refuses fsync: got %q err %v", got, err)
+	}
+}
+
 func TestWriteCertAndDoCommandWritesBothFiles(t *testing.T) {
 	root := t.TempDir()
 	c := &config.ClientCertification{
@@ -124,7 +173,7 @@ func TestWriteCertAndDoCommandWritesBothFiles(t *testing.T) {
 		SavePath: root,
 		Domains:  []string{"example.com"},
 	}
-	writeCertAndDoCommand([]byte("CERT"), []byte("KEY"), c)
+	writeCertAndDoCommand(context.Background(), []byte("CERT"), []byte("KEY"), c)
 
 	cert, err := os.ReadFile(filepath.Join(root, "site.pem"))
 	if err != nil {
@@ -176,7 +225,7 @@ func TestWriteCertAndDoCommandWhitespaceReloadCommand(t *testing.T) {
 			t.Fatalf("panicked on whitespace ReloadCommand: %v", r)
 		}
 	}()
-	writeCertAndDoCommand([]byte("CERT"), []byte("KEY"), c)
+	writeCertAndDoCommand(context.Background(), []byte("CERT"), []byte("KEY"), c)
 }
 
 // TestWriteCertAndDoCommandSkipsReloadOnFirstInstall covers the
@@ -198,7 +247,7 @@ func TestWriteCertAndDoCommandSkipsReloadOnFirstInstall(t *testing.T) {
 		}
 	}()
 	// First install — files don't exist yet — reload must not run.
-	writeCertAndDoCommand([]byte("CERT"), []byte("KEY"), c)
+	writeCertAndDoCommand(context.Background(), []byte("CERT"), []byte("KEY"), c)
 
 	if _, err := os.Stat(filepath.Join(root, "site.pem")); err != nil {
 		t.Errorf("cert was not written: %v", err)
@@ -214,6 +263,73 @@ func TestWriteCertAndDoCommandEmptySavePath(t *testing.T) {
 			t.Fatalf("panicked on empty save path: %v", r)
 		}
 	}()
-	writeCertAndDoCommand([]byte("CERT"), []byte("KEY"), c)
+	writeCertAndDoCommand(context.Background(), []byte("CERT"), []byte("KEY"), c)
 	// Nothing to assert on disk — just that we returned cleanly.
+}
+
+// TestRunReloadCommandKillsHungCommand pins the hang fix: a reload
+// command that never exits must be killed at the timeout so the sole
+// UpdateChan consumer regains control.
+func TestRunReloadCommandKillsHungCommand(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runReloadCommand(context.Background(), "sleep 30", 100*time.Millisecond)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runReloadCommand did not return, hung reload wedges the watcher")
+	}
+}
+
+// TestRunReloadCommandHonoursContext covers the daemon-stop path: a
+// cancelled root context must terminate the reload command too.
+func TestRunReloadCommandHonoursContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runReloadCommand(ctx, "sleep 30", time.Minute)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runReloadCommand ignored context cancellation")
+	}
+}
+
+// TestWriteCertKeyPairAtomicSeparateDirs covers cert and key living in
+// different directories: both renames must land, and the parent-dir
+// syncs must not turn a successful write into an error.
+func TestWriteCertKeyPairAtomicSeparateDirs(t *testing.T) {
+	certDir := t.TempDir()
+	keyDir := t.TempDir()
+	certPath := filepath.Join(certDir, "site.pem")
+	keyPath := filepath.Join(keyDir, "site.key")
+
+	if err := writeCertKeyPairAtomic(certPath, []byte("CERT"), keyPath, []byte("KEY")); err != nil {
+		t.Fatalf("writeCertKeyPairAtomic: %v", err)
+	}
+	if got, err := os.ReadFile(certPath); err != nil || string(got) != "CERT" {
+		t.Fatalf("cert: got %q err %v", got, err)
+	}
+	if got, err := os.ReadFile(keyPath); err != nil || string(got) != "KEY" {
+		t.Fatalf("key: got %q err %v", got, err)
+	}
+}
+
+// TestSyncDirMissingDirIsBestEffort: syncing a directory that isn't
+// there must not panic — the sync is durability polish, not a
+// precondition.
+func TestSyncDirMissingDirIsBestEffort(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	syncDir(filepath.Join(t.TempDir(), "nope"))
 }

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -12,44 +12,60 @@ import (
 
 	"pkg.para.party/certdx/pkg/api"
 	"pkg.para.party/certdx/pkg/config"
-	"pkg.para.party/certdx/pkg/logging"
 	"pkg.para.party/certdx/pkg/mtls"
 )
+
+// httpIdleConnTimeout bounds how long an idle keep-alive connection is
+// kept alive. Clients are built once per server and reused, but a
+// bounded idle timeout still keeps sockets from piling up when the peer
+// goes away.
+const httpIdleConnTimeout = 90 * time.Second
 
 type CertDXHttpClient struct {
 	HttpClient *http.Client
 	Server     *config.ClientHttpServer
 }
 
-type CertDXHttpClientOption func(client *CertDXHttpClient)
+// CertDXHttpClientOption customises a client under construction. An
+// option that cannot be satisfied (e.g. an unreadable mTLS bundle)
+// returns an error, which MakeCertDXHttpClient surfaces to the caller.
+// Options must never be process-fatal: this code also runs inside the
+// Caddy plugin and certdx_tools, where killing the host process on a
+// transient file error is unacceptable.
+type CertDXHttpClientOption func(client *CertDXHttpClient) error
+
+func newTLSTransport(cfg *tls.Config) *http.Transport {
+	return &http.Transport{
+		TLSClientConfig: cfg,
+		IdleConnTimeout: httpIdleConnTimeout,
+	}
+}
 
 func WithCertDXServerInfo(server *config.ClientHttpServer) CertDXHttpClientOption {
-	return func(client *CertDXHttpClient) {
+	return func(client *CertDXHttpClient) error {
 		client.Server = server
 
 		if server.AuthMethod == config.HTTP_AUTH_MTLS {
 			cfg, err := mtls.LoadClient(server.PEM)
 			if err != nil {
-				logging.Fatal("load mtls bundle: %s", err)
+				return fmt.Errorf("load mtls bundle: %w", err)
 			}
-			client.HttpClient.Transport = &http.Transport{
-				TLSClientConfig: cfg,
-			}
+			client.HttpClient.Transport = newTLSTransport(cfg)
 		}
+		return nil
 	}
 }
 
 func WithCertDXInsecure() CertDXHttpClientOption {
-	return func(client *CertDXHttpClient) {
-		client.HttpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		}
+	return func(client *CertDXHttpClient) error {
+		client.HttpClient.Transport = newTLSTransport(&tls.Config{
+			InsecureSkipVerify: true,
+		})
+		return nil
 	}
 }
 
-func MakeCertDXHttpClient(s ...CertDXHttpClientOption) *CertDXHttpClient {
+func MakeCertDXHttpClient(s ...CertDXHttpClientOption) (*CertDXHttpClient, error) {
 	ret := &CertDXHttpClient{
 		HttpClient: &http.Client{
 			Timeout: 30 * time.Second,
@@ -57,10 +73,12 @@ func MakeCertDXHttpClient(s ...CertDXHttpClientOption) *CertDXHttpClient {
 	}
 
 	for _, item := range s {
-		item(ret)
+		if err := item(ret); err != nil {
+			return nil, err
+		}
 	}
 
-	return ret
+	return ret, nil
 }
 
 func (c *CertDXHttpClient) makeGetCertRequest(ctx context.Context, domains []string) (*http.Request, error) {

--- a/pkg/client/http_poller.go
+++ b/pkg/client/http_poller.go
@@ -8,14 +8,83 @@ import (
 	"pkg.para.party/certdx/pkg/retry"
 )
 
+// Poll pacing. sleepTime is normally derived from the server's
+// RenewTimeLeft; the constants below keep that derivation sane and give
+// a failed round something shorter than a full success interval to wait
+// on.
+const (
+	// httpPollDefaultInterval is used until the server has told us how
+	// much of the cert lifetime is left.
+	httpPollDefaultInterval = 1 * time.Hour
+	// httpPollMinInterval is the fallback interval for a server that
+	// reports a zero or negative RenewTimeLeft: the number is unusable,
+	// so we fall back to a fixed cadence rather than spin.
+	httpPollMinInterval = 1 * time.Minute
+	// httpPollFloorInterval is the absolute lower bound on a
+	// server-derived interval, guarding a sub-second RenewTimeLeft from
+	// turning the loop into a tight request loop. It is itself clamped to
+	// RenewTimeLeft, so it can never stretch a poll beyond the server's
+	// own renewal margin.
+	httpPollFloorInterval = 1 * time.Second
+	// httpPollRetryInterval / httpPollMaxRetryInterval bound the backoff
+	// used when the server could not be reached at all.
+	httpPollRetryInterval    = 15 * time.Second
+	httpPollMaxRetryInterval = 60 * time.Second
+)
+
+// pollInterval derives the success-path poll interval from the
+// server-reported remaining lifetime, mirroring the server's own
+// renewer cadence of RenewTimeLeft/4.
+//
+// Only the pathological cases are clamped. A blanket one-minute floor
+// would be wrong for short-lived certs: with RenewTimeLeft below four
+// minutes it polls slower than the server renews, and below one minute
+// the poll interval would exceed the whole renewal margin, letting the
+// client serve an expired cert. So the floor is itself capped by
+// renewTimeLeft and never exceeds it.
+func pollInterval(renewTimeLeft time.Duration) time.Duration {
+	if renewTimeLeft <= 0 {
+		// Unusable number: don't derive anything from it.
+		return httpPollMinInterval
+	}
+	return max(renewTimeLeft/4, min(httpPollFloorInterval, renewTimeLeft))
+}
+
+// nextRetryInterval doubles the failure backoff up to the cap.
+func nextRetryInterval(current time.Duration) time.Duration {
+	return min(2*current, httpPollMaxRetryInterval)
+}
+
+// pollWait decides how long the poll loop sleeps after a round and what
+// the transport backoff should be on the next one.
+//
+// The short doubling backoff is reserved for resp == nil, i.e. neither
+// server could be reached: retry.Do can bail out in milliseconds
+// (connection refused fast-fails), so waiting out a full success
+// interval would black the cert out for an hour.
+//
+// A non-empty resp.Err is a different animal: the server answered, and
+// answered with a considered error ("Domains not allowed"). That is
+// usually permanent and never fixed by hammering, so it waits the
+// success interval and resets the transport backoff — the fast backoff
+// exists for a dead socket, not for a healthy server saying no.
+func pollWait(resp *api.HttpCertResp, successInterval, retryInterval time.Duration) (wait, nextRetry time.Duration) {
+	if resp == nil {
+		return retryInterval, nextRetryInterval(retryInterval)
+	}
+	return successInterval, httpPollRetryInterval
+}
+
 // httpRequestCert fetches the cert for domains from the configured main
 // HTTP server, falling back to the standby server if the main fails the
 // retry budget. Returns nil only when both are unreachable.
 func (r *CertDXClientDaemon) httpRequestCert(domains []string) *api.HttpCertResp {
 	var resp *api.HttpCertResp
 	err := retry.Do(r.rootCtx, r.Config.Common.RetryCount, func() error {
-		certdxClient := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(&r.Config.Http.MainServer))...)
-		var err error
+		certdxClient, err := r.httpClientFor(&r.Config.Http.MainServer)
+		if err != nil {
+			return err
+		}
 		resp, err = certdxClient.GetCertCtx(r.rootCtx, domains)
 		return err
 	})
@@ -25,9 +94,11 @@ func (r *CertDXClientDaemon) httpRequestCert(domains []string) *api.HttpCertResp
 	logging.Warn("Failed to get cert %v from MainServer, err: %s", domains, err)
 
 	if r.Config.Http.StandbyServer.Url != "" {
-		certdxClient := MakeCertDXHttpClient(append(r.ClientOpt, WithCertDXServerInfo(&r.Config.Http.StandbyServer))...)
 		err = retry.Do(r.rootCtx, r.Config.Common.RetryCount, func() error {
-			var err error
+			certdxClient, err := r.httpClientFor(&r.Config.Http.StandbyServer)
+			if err != nil {
+				return err
+			}
 			resp, err = certdxClient.GetCertCtx(r.rootCtx, domains)
 			return err
 		})
@@ -41,32 +112,47 @@ func (r *CertDXClientDaemon) httpRequestCert(domains []string) *api.HttpCertResp
 
 // httpPollingCert is the per-cert HTTP-mode poll loop. It requests the
 // cert, hands the result to the watcher via cert.UpdateChan, and sleeps
-// for RenewTimeLeft/4 (or one hour by default) before the next round.
+// for RenewTimeLeft/4 — or one hour by default — before the next round.
+// A round in which the server could not be reached at all waits on a
+// short doubling backoff instead, so a dead server is retried in
+// seconds rather than after a full success interval.
 // Exits when rootCtx fires.
 func (r *CertDXClientDaemon) httpPollingCert(cert *watchingCert) {
-	sleepTime := 1 * time.Hour // default sleep time
+	sleepTime := httpPollDefaultInterval // default sleep time
+	retryInterval := httpPollRetryInterval
 	for {
 		logging.Info("Requesting cert %v", cert.Config.Domains)
 		resp := r.httpRequestCert(cert.Config.Domains)
-		if resp != nil {
-			if resp.Err != "" {
-				logging.Error("Failed to request cert, err: %s", resp.Err)
-			} else {
-				sleepTime = resp.RenewTimeLeft / 4
-				select {
-				case cert.UpdateChan <- certData{
-					Domains:   cert.Config.Domains,
-					Fullchain: resp.FullChain,
-					Key:       resp.Key,
-				}:
-				case <-r.rootCtx.Done():
-					return
-				}
-			}
-		} else {
+		switch {
+		case resp == nil:
+			// Transport failure: no server answered.
 			logging.Error("Failed to request cert, retry next round.")
+		case resp.Err != "":
+			// The server answered and refused. Usually permanent
+			// (mis-configured domains, missing auth), so it is not worth
+			// the fast retry backoff.
+			logging.Error("Server refused cert request %v, err: %s", cert.Config.Domains, resp.Err)
+		default:
+			if resp.RenewTimeLeft <= 0 {
+				logging.Warn("Server reported renew time left %s for cert %v, polling every %s instead",
+					resp.RenewTimeLeft, cert.Config.Domains, httpPollMinInterval)
+			}
+			sleepTime = pollInterval(resp.RenewTimeLeft)
+			select {
+			case cert.UpdateChan <- certData{
+				Domains:   cert.Config.Domains,
+				Fullchain: resp.FullChain,
+				Key:       resp.Key,
+			}:
+			case <-r.rootCtx.Done():
+				return
+			}
 		}
-		t := time.NewTimer(sleepTime)
+
+		wait, nextRetry := pollWait(resp, sleepTime, retryInterval)
+		retryInterval = nextRetry
+
+		t := time.NewTimer(wait)
 		select {
 		case <-t.C:
 			// continue

--- a/pkg/client/http_poller_test.go
+++ b/pkg/client/http_poller_test.go
@@ -1,0 +1,143 @@
+package client
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"pkg.para.party/certdx/pkg/api"
+	"pkg.para.party/certdx/pkg/config"
+)
+
+// TestPollIntervalFloors pins the poll-interval clamp: a server that
+// reports a zero or negative RenewTimeLeft must not put the poller in a
+// tight request loop, while every usable RenewTimeLeft — including
+// short-lived certs measured in seconds — must still be polled at the
+// server's own RenewTimeLeft/4 cadence.
+func TestPollIntervalFloors(t *testing.T) {
+	cases := []struct {
+		renewTimeLeft time.Duration
+		want          time.Duration
+	}{
+		{0, httpPollMinInterval},
+		{-24 * time.Hour, httpPollMinInterval},
+		// Sub-second lifetime: clamped, but never past the margin itself.
+		{100 * time.Millisecond, 100 * time.Millisecond},
+		{time.Second, time.Second},
+		// Short-lived certs (the e2e config uses certLifeTime 30s /
+		// renewTimeLeft 16s) must keep their RenewTimeLeft/4 cadence.
+		{16 * time.Second, 4 * time.Second},
+		{2 * time.Minute, 30 * time.Second},
+		{8 * time.Hour, 2 * time.Hour},
+	}
+	for _, tc := range cases {
+		if got := pollInterval(tc.renewTimeLeft); got != tc.want {
+			t.Errorf("pollInterval(%s): got %s want %s", tc.renewTimeLeft, got, tc.want)
+		}
+	}
+}
+
+// TestPollIntervalNeverExceedsRenewMargin is the invariant behind the
+// clamp: polling slower than the server's own renewal margin means the
+// client can serve an expired cert.
+func TestPollIntervalNeverExceedsRenewMargin(t *testing.T) {
+	for _, renewTimeLeft := range []time.Duration{
+		time.Millisecond, 100 * time.Millisecond, time.Second, 4 * time.Second,
+		16 * time.Second, 45 * time.Second, time.Minute, 2 * time.Minute,
+		4 * time.Minute, time.Hour,
+	} {
+		if got := pollInterval(renewTimeLeft); got > renewTimeLeft {
+			t.Errorf("pollInterval(%s) = %s exceeds the renewal margin", renewTimeLeft, got)
+		}
+	}
+}
+
+// TestPollWaitServerErrorIsNotTransportFailure pins the split between
+// "the server answered with an error" and "nothing answered". A
+// permanent, actionable server error (HTTP 200 + resp.Err) must not be
+// hammered on the 15s→60s transport backoff forever.
+func TestPollWaitServerErrorIsNotTransportFailure(t *testing.T) {
+	const success = 30 * time.Minute
+
+	// Transport failure: short backoff, and it doubles.
+	wait, next := pollWait(nil, success, httpPollRetryInterval)
+	if wait != httpPollRetryInterval {
+		t.Errorf("transport failure wait: got %s want %s", wait, httpPollRetryInterval)
+	}
+	if next != nextRetryInterval(httpPollRetryInterval) {
+		t.Errorf("transport failure backoff: got %s want %s", next, nextRetryInterval(httpPollRetryInterval))
+	}
+
+	// Server answered with an error: success interval, backoff reset.
+	wait, next = pollWait(&api.HttpCertResp{Err: "Domains not allowed"}, success, httpPollMaxRetryInterval)
+	if wait != success {
+		t.Errorf("server error wait: got %s want %s", wait, success)
+	}
+	if next != httpPollRetryInterval {
+		t.Errorf("server error must reset the transport backoff: got %s want %s", next, httpPollRetryInterval)
+	}
+
+	// Success: success interval, backoff reset.
+	wait, next = pollWait(&api.HttpCertResp{}, success, httpPollMaxRetryInterval)
+	if wait != success {
+		t.Errorf("success wait: got %s want %s", wait, success)
+	}
+	if next != httpPollRetryInterval {
+		t.Errorf("success must reset the transport backoff: got %s want %s", next, httpPollRetryInterval)
+	}
+}
+
+// TestPollWaitTransportBackoffClimbsOnlyOnTransportFailure walks a few
+// rounds to show a repeatedly-refusing server never escalates the
+// transport backoff.
+func TestPollWaitTransportBackoffClimbsOnlyOnTransportFailure(t *testing.T) {
+	retryInterval := httpPollRetryInterval
+	errResp := &api.HttpCertResp{Err: "Domains not allowed"}
+	for range 5 {
+		var wait time.Duration
+		wait, retryInterval = pollWait(errResp, httpPollDefaultInterval, retryInterval)
+		if wait != httpPollDefaultInterval {
+			t.Fatalf("server error waited %s, want the success interval %s", wait, httpPollDefaultInterval)
+		}
+	}
+	if retryInterval != httpPollRetryInterval {
+		t.Fatalf("transport backoff drifted on server errors: got %s want %s", retryInterval, httpPollRetryInterval)
+	}
+}
+
+// TestNextRetryIntervalCaps checks the failure backoff doubles and then
+// stays at the cap.
+func TestNextRetryIntervalCaps(t *testing.T) {
+	interval := httpPollRetryInterval
+	for range 10 {
+		interval = nextRetryInterval(interval)
+		if interval > httpPollMaxRetryInterval {
+			t.Fatalf("backoff exceeded cap: got %s want <= %s", interval, httpPollMaxRetryInterval)
+		}
+	}
+	if interval != httpPollMaxRetryInterval {
+		t.Fatalf("backoff did not reach cap: got %s want %s", interval, httpPollMaxRetryInterval)
+	}
+	// A failed round must never wait out the success interval.
+	if httpPollMaxRetryInterval >= httpPollDefaultInterval {
+		t.Fatalf("retry backoff %s is not shorter than the success interval %s",
+			httpPollMaxRetryInterval, httpPollDefaultInterval)
+	}
+}
+
+// TestHttpRequestCertMTLSFailureIsNotFatal pins the os.Exit fix on the
+// poll path: an unreadable mTLS bundle must come back as a failed fetch
+// (nil response), not take the process down.
+func TestHttpRequestCertMTLSFailureIsNotFatal(t *testing.T) {
+	d := MakeCertDXClientDaemon()
+	d.Config.Common.RetryCount = 0
+	d.Config.Http.MainServer = config.ClientHttpServer{
+		Url:              "https://127.0.0.1:1",
+		AuthMethod:       config.HTTP_AUTH_MTLS,
+		ClientMtlsConfig: config.ClientMtlsConfig{PEM: filepath.Join(t.TempDir(), "does-not-exist.pem")},
+	}
+
+	if resp := d.httpRequestCert([]string{"example.com"}); resp != nil {
+		t.Fatalf("expected nil response for unloadable mtls bundle, got %+v", resp)
+	}
+}

--- a/pkg/client/http_test.go
+++ b/pkg/client/http_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,8 +15,17 @@ import (
 	"pkg.para.party/certdx/pkg/config"
 )
 
+func mustHttpClient(t *testing.T, opts ...CertDXHttpClientOption) *CertDXHttpClient {
+	t.Helper()
+	c, err := MakeCertDXHttpClient(opts...)
+	if err != nil {
+		t.Fatalf("MakeCertDXHttpClient: %v", err)
+	}
+	return c
+}
+
 func TestMakeCertDXHttpClientDefaults(t *testing.T) {
-	c := MakeCertDXHttpClient()
+	c := mustHttpClient(t)
 	if c.HttpClient == nil {
 		t.Fatal("HttpClient is nil")
 	}
@@ -27,7 +38,7 @@ func TestMakeCertDXHttpClientDefaults(t *testing.T) {
 }
 
 func TestWithCertDXInsecure(t *testing.T) {
-	c := MakeCertDXHttpClient(WithCertDXInsecure())
+	c := mustHttpClient(t, WithCertDXInsecure())
 	tr, ok := c.HttpClient.Transport.(*http.Transport)
 	if !ok {
 		t.Fatal("transport is not *http.Transport")
@@ -43,14 +54,14 @@ func TestWithCertDXServerInfo(t *testing.T) {
 		AuthMethod: config.HTTP_AUTH_TOKEN,
 		Token:      "tok",
 	}
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(srv))
+	c := mustHttpClient(t, WithCertDXServerInfo(srv))
 	if c.Server != srv {
 		t.Fatal("Server not set by option")
 	}
 }
 
 func TestMakeGetCertRequestMethod(t *testing.T) {
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url: "https://example.com/api",
 	}))
 
@@ -67,7 +78,7 @@ func TestMakeGetCertRequestMethod(t *testing.T) {
 }
 
 func TestMakeGetCertRequestTokenHeader(t *testing.T) {
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url:        "https://example.com",
 		AuthMethod: config.HTTP_AUTH_TOKEN,
 		Token:      "secret",
@@ -84,7 +95,7 @@ func TestMakeGetCertRequestTokenHeader(t *testing.T) {
 }
 
 func TestMakeGetCertRequestNoTokenHeader(t *testing.T) {
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url:        "https://example.com",
 		AuthMethod: config.HTTP_AUTH_TOKEN,
 		Token:      "",
@@ -100,7 +111,7 @@ func TestMakeGetCertRequestNoTokenHeader(t *testing.T) {
 }
 
 func TestMakeGetCertRequestBody(t *testing.T) {
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url: "https://example.com",
 	}))
 
@@ -136,7 +147,7 @@ func TestGetCertCtxSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url: ts.URL,
 	}))
 
@@ -161,7 +172,7 @@ func TestGetCertCtxNon200(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url: ts.URL,
 	}))
 
@@ -178,7 +189,7 @@ func TestGetCertCtxBadJSON(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url: ts.URL,
 	}))
 
@@ -200,7 +211,7 @@ func TestGetCertDelegatesToGetCertCtx(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+	c := mustHttpClient(t, WithCertDXServerInfo(&config.ClientHttpServer{
 		Url: ts.URL,
 	}))
 
@@ -210,5 +221,35 @@ func TestGetCertDelegatesToGetCertCtx(t *testing.T) {
 	}
 	if string(got.FullChain) != "fc" {
 		t.Errorf("fullchain: got %q", got.FullChain)
+	}
+}
+
+// TestWithCertDXServerInfoMTLSLoadFailure pins the fix for the
+// os.Exit-on-bad-bundle bug: a missing/broken mTLS bundle must come
+// back as an error from MakeCertDXHttpClient, never kill the process.
+func TestWithCertDXServerInfoMTLSLoadFailure(t *testing.T) {
+	_, err := MakeCertDXHttpClient(WithCertDXServerInfo(&config.ClientHttpServer{
+		Url:              "https://example.com",
+		AuthMethod:       config.HTTP_AUTH_MTLS,
+		ClientMtlsConfig: config.ClientMtlsConfig{PEM: filepath.Join(t.TempDir(), "does-not-exist.pem")},
+	}))
+	if err == nil {
+		t.Fatal("expected error for unreadable mtls bundle")
+	}
+	if !strings.Contains(err.Error(), "load mtls bundle") {
+		t.Errorf("error wrap: %v", err)
+	}
+}
+
+// TestTransportsBoundIdleConns guards against the per-poll transport
+// leak: transports we build must expire idle connections.
+func TestTransportsBoundIdleConns(t *testing.T) {
+	c := mustHttpClient(t, WithCertDXInsecure())
+	tr, ok := c.HttpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("transport is not *http.Transport")
+	}
+	if tr.IdleConnTimeout != httpIdleConnTimeout {
+		t.Fatalf("IdleConnTimeout: got %v want %v", tr.IdleConnTimeout, httpIdleConnTimeout)
 	}
 }

--- a/pkg/client/sds.go
+++ b/pkg/client/sds.go
@@ -34,7 +34,12 @@ type respData struct {
 }
 
 type CertDXgRPCClient struct {
-	tlsCred credentials.TransportCredentials
+	// tlsCred caches the mTLS credentials once they load successfully.
+	// Loading is deferred to the first Stream so a bad or not-yet-present
+	// bundle is a retryable stream error rather than a process-fatal
+	// one — this client also runs inside the Caddy plugin and
+	// certdx_tools, where killing the host process is unacceptable.
+	tlsCred atomic.Pointer[credentials.TransportCredentials]
 	server  *config.ClientGRPCServer
 	certs   map[domain.Key]*watchingCert
 
@@ -57,12 +62,25 @@ func MakeCertDXgRPCClient(server *config.ClientGRPCServer, certs map[domain.Key]
 	received := make(chan struct{})
 	c.Received.Store(&received)
 	c.Running.Store(false)
-	cfg, err := mtls.LoadClient(server.PEM)
-	if err != nil {
-		logging.Fatal("load mtls bundle: %s", err)
-	}
-	c.tlsCred = credentials.NewTLS(cfg)
 	return c
+}
+
+// transportCredentials returns the client's mTLS credentials, loading
+// the bundle on first use and caching it afterwards. A load failure is
+// returned to the caller, which surfaces it as a stream error and lets
+// the failover state machine retry.
+func (c *CertDXgRPCClient) transportCredentials() (credentials.TransportCredentials, error) {
+	if cred := c.tlsCred.Load(); cred != nil {
+		return *cred, nil
+	}
+
+	cfg, err := mtls.LoadClient(c.server.PEM)
+	if err != nil {
+		return nil, fmt.Errorf("load mtls bundle: %w", err)
+	}
+	cred := credentials.NewTLS(cfg)
+	c.tlsCred.Store(&cred)
+	return cred, nil
 }
 
 func sendStreamErr(ctx context.Context, errChan chan<- error, err error) {
@@ -72,7 +90,26 @@ func sendStreamErr(ctx context.Context, errChan chan<- error, err error) {
 	}
 }
 
+// checkCertNames rejects duplicate cert pack names before anything goes
+// on the wire. The name is the dispatch key for incoming secrets and
+// also keys the Node.Metadata domain sets we send, so a duplicate would
+// silently overwrite both and starve one cert of updates forever.
+func (c *CertDXgRPCClient) checkCertNames() error {
+	seen := make(map[string]struct{}, len(c.certs))
+	for _, cert := range c.certs {
+		if _, dup := seen[cert.Config.Name]; dup {
+			return fmt.Errorf("duplicate certificate name %q in watched certs", cert.Config.Name)
+		}
+		seen[cert.Config.Name] = struct{}{}
+	}
+	return nil
+}
+
 func (c *CertDXgRPCClient) Stream(ctx context.Context) error {
+	if err := c.checkCertNames(); err != nil {
+		return err
+	}
+
 	streamCtx, cancel := context.WithCancel(ctx)
 	c.cancel.Store(&cancel)
 	defer func() {
@@ -80,8 +117,13 @@ func (c *CertDXgRPCClient) Stream(ctx context.Context) error {
 		c.cancel.Store(nil)
 	}()
 
+	tlsCred, err := c.transportCredentials()
+	if err != nil {
+		return err
+	}
+
 	conn, err := grpc.NewClient(c.server.Server,
-		grpc.WithTransportCredentials(c.tlsCred),
+		grpc.WithTransportCredentials(tlsCred),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    30 * time.Second,
 			Timeout: 25 * time.Second,

--- a/pkg/client/sds_test.go
+++ b/pkg/client/sds_test.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pkg.para.party/certdx/pkg/config"
+	"pkg.para.party/certdx/pkg/domain"
+)
+
+// TestStreamRejectsDuplicateCertNames pins the dispatch-starvation
+// guard: two cert packs sharing a Name would collide in the dispatch
+// map and in the Node.Metadata domain sets, so Stream must refuse
+// before anything reaches the wire.
+func TestStreamRejectsDuplicateCertNames(t *testing.T) {
+	certs := map[domain.Key]*watchingCert{}
+	for _, domains := range [][]string{{"a.example.com"}, {"b.example.com"}} {
+		certs[domain.AsKey(domains)] = &watchingCert{
+			Config:     config.ClientCertification{Name: "dup", Domains: domains},
+			UpdateChan: make(chan certData, 1),
+		}
+	}
+
+	c := MakeCertDXgRPCClient(&config.ClientGRPCServer{Server: "127.0.0.1:1"}, certs)
+	err := c.Stream(context.Background())
+	if err == nil {
+		t.Fatal("expected error for duplicate cert names")
+	}
+	if !strings.Contains(err.Error(), "duplicate certificate name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestStreamMTLSFailureIsNotFatal pins the os.Exit fix on the gRPC
+// side: an unreadable bundle surfaces as a stream error the failover
+// state machine can retry.
+func TestStreamMTLSFailureIsNotFatal(t *testing.T) {
+	c := MakeCertDXgRPCClient(&config.ClientGRPCServer{
+		Server:           "127.0.0.1:1",
+		ClientMtlsConfig: config.ClientMtlsConfig{PEM: filepath.Join(t.TempDir(), "does-not-exist.pem")},
+	}, map[domain.Key]*watchingCert{})
+
+	err := c.Stream(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unreadable mtls bundle")
+	}
+	if !strings.Contains(err.Error(), "load mtls bundle") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	"pkg.para.party/certdx/pkg/domain"
 	"pkg.para.party/certdx/pkg/paths"
 )
 
@@ -41,9 +42,38 @@ func (c *ClientConfig) Validate(optionList []ValidatingOption) error {
 		ret = append(ret, fmt.Errorf("no certification configured"))
 	}
 
+	// A certification name is only a global identifier in gRPC/SDS mode, where
+	// it is the SDS resource name on the wire (pkg/client/sds.go guards this
+	// again at runtime). In HTTP mode the on-disk identity is savePath + name
+	// and the daemon keys its watch map on the domain set, so the same name
+	// under two different savePaths is a perfectly good config and has always
+	// loaded. Only an identical savePath + name pair is a real collision
+	// there: both entries would write the same .pem/.key files.
+	grpcMode := c.Common.Mode == CLIENT_MODE_GRPC
+	seenNames := make(map[string]struct{}, len(c.Certifications))
+	seenDomains := make(map[domain.Key]string, len(c.Certifications))
 	for _, cert := range c.Certifications {
 		if err := cert.Validate(option); err != nil {
 			ret = append(ret, err)
+			continue
+		}
+
+		if nameKey, dupErr := certNameKey(cert, grpcMode); nameKey != "" {
+			if _, ok := seenNames[nameKey]; ok {
+				ret = append(ret, dupErr)
+			} else {
+				seenNames[nameKey] = struct{}{}
+			}
+		}
+
+		// Two certifications over the same domain set would race each other
+		// writing the same cert, so they have to be merged in the config.
+		key := domain.AsKey(cert.Domains)
+		if first, ok := seenDomains[key]; ok {
+			ret = append(ret, fmt.Errorf("certification %s duplicates the domain set of %s: %v",
+				cert.Name, first, cert.Domains))
+		} else {
+			seenDomains[key] = cert.Name
 		}
 	}
 
@@ -63,6 +93,21 @@ func (c *ClientConfig) Validate(optionList []ValidatingOption) error {
 	}
 
 	return errors.Join(ret...)
+}
+
+// certNameKey returns the uniqueness key for one certification's name, plus
+// the error to report when that key repeats. An empty key means the name has
+// no identity worth checking here (non-gRPC mode with no savePath, e.g. an
+// embedder that never writes files).
+func certNameKey(cert ClientCertification, grpcMode bool) (string, error) {
+	if grpcMode {
+		return cert.Name, fmt.Errorf("duplicate certification name: %s", cert.Name)
+	}
+	if cert.SavePath == "" {
+		return "", nil
+	}
+	return cert.SavePath + "\x00" + cert.Name,
+		fmt.Errorf("duplicate certification name: %s under savePath %s", cert.Name, cert.SavePath)
 }
 
 func (c *ClientConfig) parseDuration() error {

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -185,6 +185,100 @@ func TestClientConfigValidateHttpTokenNoMtlsCheck(t *testing.T) {
 	}
 }
 
+func TestClientConfigValidateDuplicateNames(t *testing.T) {
+	c := &ClientConfig{}
+	c.SetDefault()
+	c.Http.MainServer.Url = "https://example.com"
+	// Same name AND same savePath: both entries would write the same
+	// /tmp/x.pem and /tmp/x.key.
+	c.Certifications = []ClientCertification{
+		{Name: "x", SavePath: "/tmp", Domains: []string{"a.example.com"}},
+		{Name: "x", SavePath: "/tmp", Domains: []string{"b.example.com"}},
+	}
+	err := c.Validate(nil)
+	if err == nil {
+		t.Fatal("expected error on duplicate certification name")
+	}
+	if !strings.Contains(err.Error(), "duplicate certification name") {
+		t.Fatalf("error wording drifted: %v", err)
+	}
+}
+
+// TestClientConfigValidateSameNameDifferentSavePath locks the backward-compat
+// fix: in HTTP mode the on-disk identity is savePath + name, so reusing a name
+// under a different savePath is a valid config and must keep loading.
+func TestClientConfigValidateSameNameDifferentSavePath(t *testing.T) {
+	c := &ClientConfig{}
+	c.SetDefault()
+	c.Common.Mode = CLIENT_MODE_HTTP
+	c.Http.MainServer.Url = "https://example.com"
+	c.Certifications = []ClientCertification{
+		{Name: "site", SavePath: "/etc/nginx/certs", Domains: []string{"a.example.com"}},
+		{Name: "site", SavePath: "/etc/haproxy/certs", Domains: []string{"b.example.com"}},
+	}
+	if err := c.Validate(nil); err != nil {
+		t.Fatalf("same name under different savePaths should validate: %v", err)
+	}
+}
+
+// TestClientConfigValidateGrpcDuplicateNames keeps the global name check where
+// it matters: the name is the SDS resource name on the wire in gRPC mode.
+func TestClientConfigValidateGrpcDuplicateNames(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "client.pem")
+	if err := os.WriteFile(bundle, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := &ClientConfig{}
+	c.SetDefault()
+	c.Common.Mode = CLIENT_MODE_GRPC
+	c.GRPC.MainServer.Server = "localhost:10002"
+	c.GRPC.MainServer.PEM = bundle
+	c.Certifications = []ClientCertification{
+		{Name: "site", SavePath: "/etc/nginx/certs", Domains: []string{"a.example.com"}},
+		{Name: "site", SavePath: "/etc/haproxy/certs", Domains: []string{"b.example.com"}},
+	}
+	err := c.Validate(nil)
+	if err == nil {
+		t.Fatal("expected error on duplicate SDS resource name in grpc mode")
+	}
+	if !strings.Contains(err.Error(), "duplicate certification name") {
+		t.Fatalf("error wording drifted: %v", err)
+	}
+}
+
+func TestClientConfigValidateDuplicateDomainSets(t *testing.T) {
+	c := &ClientConfig{}
+	c.SetDefault()
+	c.Http.MainServer.Url = "https://example.com"
+	// Same domain set, differing only in case and order.
+	c.Certifications = []ClientCertification{
+		{Name: "x", SavePath: "/tmp", Domains: []string{"a.example.com", "b.example.com"}},
+		{Name: "y", SavePath: "/tmp", Domains: []string{"B.example.com", "a.example.com."}},
+	}
+	err := c.Validate(nil)
+	if err == nil {
+		t.Fatal("expected error on duplicate domain set")
+	}
+	if !strings.Contains(err.Error(), "duplicates the domain set") {
+		t.Fatalf("error wording drifted: %v", err)
+	}
+}
+
+func TestClientConfigValidateDistinctCertifications(t *testing.T) {
+	c := &ClientConfig{}
+	c.SetDefault()
+	c.Http.MainServer.Url = "https://example.com"
+	c.Certifications = []ClientCertification{
+		{Name: "x", SavePath: "/tmp", Domains: []string{"a.example.com"}},
+		{Name: "y", SavePath: "/tmp", Domains: []string{"b.example.com"}},
+	}
+	if err := c.Validate(nil); err != nil {
+		t.Fatalf("distinct certifications should validate: %v", err)
+	}
+}
+
 func TestClientConfigSetDefault(t *testing.T) {
 	c := &ClientConfig{}
 	c.SetDefault()

--- a/pkg/config/samples_test.go
+++ b/pkg/config/samples_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// decodeSample loads a shipped sample from config/ the same way
+// cli.LoadTOML does (SetDefault first, then decode over it) and reports
+// every key the sample sets that no config struct field claims.
+func decodeSample(t *testing.T, name string, target interface{ SetDefault() }) {
+	t.Helper()
+
+	target.SetDefault()
+	b, err := os.ReadFile(filepath.Join("..", "..", "config", name))
+	if err != nil {
+		t.Fatalf("read sample %s: %v", name, err)
+	}
+	meta, err := toml.Decode(string(b), target)
+	if err != nil {
+		t.Fatalf("parse sample %s: %v", name, err)
+	}
+	for _, key := range meta.Undecoded() {
+		t.Errorf("sample %s sets unknown key %q", name, key)
+	}
+}
+
+// TestSampleServerConfigs guards the shipped server samples against
+// drifting away from the config structs and the validation rules. The
+// _full sample documents every knob, including mutually exclusive ones,
+// so only the minimal sample is expected to validate as-is.
+func TestSampleServerConfigs(t *testing.T) {
+	for _, name := range []string{"server_config.toml", "server_config_full.toml"} {
+		t.Run(name, func(t *testing.T) {
+			decodeSample(t, name, &ServerConfig{})
+		})
+	}
+
+	t.Run("server_config.toml validates", func(t *testing.T) {
+		c := &ServerConfig{}
+		decodeSample(t, "server_config.toml", c)
+		if err := c.Validate(); err != nil {
+			t.Errorf("sample server_config.toml does not validate: %v", err)
+		}
+	})
+}
+
+// TestS3ACLTOMLDecoding pins how the acl key decodes, since the whole
+// backward-compat story rests on it: an absent acl stays nil (and resolves to
+// the historical public-read), acl = "" is an explicit opt-out of the header.
+func TestS3ACLTOMLDecoding(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"absent", "bucket = \"b\"\n", DefaultS3ACL},
+		{"explicit empty", "bucket = \"b\"\nacl = \"\"\n", ""},
+		{"explicit value", "bucket = \"b\"\nacl = \"private\"\n", "private"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s3 S3Client
+			if _, err := toml.Decode(tc.body, &s3); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got := s3.ResolvedACL(); got != tc.want {
+				t.Errorf("ResolvedACL() = %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSampleClientConfigs does the same for the client samples.
+func TestSampleClientConfigs(t *testing.T) {
+	for _, name := range []string{"client_config.toml", "client_config_full.toml"} {
+		t.Run(name, func(t *testing.T) {
+			decodeSample(t, name, &ClientConfig{})
+		})
+	}
+
+	t.Run("client_config.toml validates", func(t *testing.T) {
+		c := &ClientConfig{}
+		decodeSample(t, "client_config.toml", c)
+		if err := c.Validate(nil); err != nil {
+			t.Errorf("sample client_config.toml does not validate: %v", err)
+		}
+	})
+}

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -3,12 +3,22 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
 	"pkg.para.party/certdx/pkg/acme/acmeproviders"
+	"pkg.para.party/certdx/pkg/logging"
 	"pkg.para.party/certdx/pkg/paths"
 )
+
+// providerMaxCertLifeTime is the longest validity the known ACME providers
+// will issue. Let's Encrypt and Google Trust Services both cap at 90 days;
+// asking for more yields a cert that really expires long before the server
+// thinks it does.
+const providerMaxCertLifeTime = 90 * 24 * time.Hour
 
 type ServerConfig struct {
 	ACME ACMEConfig `toml:"ACME" json:"acme,omitempty"`
@@ -87,6 +97,43 @@ func (c *ServerConfig) parseDuration() error {
 		return fmt.Errorf("can not parse RenewTimeLeft: %w", err)
 	}
 
+	if c.ACME.CertLifeTimeDuration <= 0 {
+		return fmt.Errorf("CertLifeTime must be positive, got %q", c.ACME.CertLifeTime)
+	}
+
+	if c.ACME.RenewTimeLeftDuration <= 0 {
+		return fmt.Errorf("RenewTimeLeft must be positive, got %q", c.ACME.RenewTimeLeft)
+	}
+
+	// RenewTimeLeft == CertLifeTime is the "renew at half life" setup and is
+	// perfectly fine; only a renew window longer than the life time is
+	// pathological (the cert would be due for renewal before it is issued).
+	if c.ACME.RenewTimeLeftDuration > c.ACME.CertLifeTimeDuration {
+		return fmt.Errorf("RenewTimeLeft (%q) must not be longer than CertLifeTime (%q)",
+			c.ACME.RenewTimeLeft, c.ACME.CertLifeTime)
+	}
+
+	// A cert is requested to stay valid for CertLifeTime + RenewTimeLeft.
+	//
+	// Only Google's ACME gets that sum put on the wire as the order's
+	// NotAfter (see acme.needNotAfter), so asking for more than the provider
+	// maximum there is a hard order failure and is rejected here. Every other
+	// provider ignores the requested lifetime entirely: the server takes what
+	// it is given and clamps ValidBefore against the issued leaf's real
+	// NotAfter, so an over-long CertLifeTime self-corrects at runtime. That
+	// configuration has always loaded, so it stays a warning.
+	if acmeproviders.Supported(c.ACME.Provider) && !acmeproviders.IsMock(c.ACME.Provider) {
+		if total := c.ACME.CertLifeTimeDuration + c.ACME.RenewTimeLeftDuration; total > providerMaxCertLifeTime {
+			if acmeproviders.IsGoogle(c.ACME.Provider) {
+				return fmt.Errorf("CertLifeTime (%q) + RenewTimeLeft (%q) is %s, longer than the %s ACME provider %q can issue",
+					c.ACME.CertLifeTime, c.ACME.RenewTimeLeft, total, providerMaxCertLifeTime, c.ACME.Provider)
+			}
+			logging.Warn("CertLifeTime (%q) + RenewTimeLeft (%q) is %s, longer than the %s ACME provider %q can issue; "+
+				"certificates will be renewed on their real expiry instead",
+				c.ACME.CertLifeTime, c.ACME.RenewTimeLeft, total, providerMaxCertLifeTime, c.ACME.Provider)
+		}
+	}
+
 	return nil
 }
 
@@ -99,6 +146,10 @@ type ACMEConfig struct {
 	RenewTimeLeft  string   `toml:"renewTimeLeft" json:"renew_time_left,omitempty"`
 	AllowedDomains []string `toml:"allowedDomains" json:"allowed_domains,omitempty"`
 
+	// MaxCacheEntries caps the number of distinct cert packs the cert cache
+	// keeps. Zero (the default) means unlimited.
+	MaxCacheEntries int `toml:"maxCacheEntries" json:"max_cache_entries,omitempty"`
+
 	CertLifeTimeDuration  time.Duration `toml:"-" json:"-"`
 	RenewTimeLeftDuration time.Duration `toml:"-" json:"-"`
 }
@@ -106,6 +157,10 @@ type ACMEConfig struct {
 func (c *ACMEConfig) Validate() error {
 	if len(c.AllowedDomains) == 0 {
 		return fmt.Errorf("AllowedDomains is empty")
+	}
+
+	if c.MaxCacheEntries < 0 {
+		return fmt.Errorf("MaxCacheEntries must not be negative, got %d", c.MaxCacheEntries)
 	}
 
 	if acmeproviders.IsMock(c.Provider) {
@@ -161,6 +216,11 @@ func (p *DnsProvider) Validate() error {
 			return fmt.Errorf("DnsProvider: dnsTimeout must be positive, got %q", p.DNSTimeout)
 		}
 	}
+	for _, ns := range p.Nameservers {
+		if err := validateNameserver(ns); err != nil {
+			return fmt.Errorf("DnsProvider: %w", err)
+		}
+	}
 	switch p.Type {
 	case DnsProviderTypeCloudflare:
 		if (p.Email == "" || p.APIKey == "") && (p.AuthToken == "" || p.ZoneToken == "") {
@@ -171,9 +231,73 @@ func (p *DnsProvider) Validate() error {
 			return fmt.Errorf("DnsProvider TencentCloud: empty SecretID or SecretKey")
 		}
 	default:
-		return fmt.Errorf("unknown DnsProvider: %s", p.Type)
+		return fmt.Errorf("unknown DnsProvider: %s, expected one of: %s, %s",
+			p.Type, DnsProviderTypeCloudflare, DnsProviderTypeTencentCloud)
 	}
 	return nil
+}
+
+// validateNameserver checks that a recursive nameserver entry is a plain
+// host[:port] pair, the shape lego's dns01.ParseNameservers expects. The port
+// defaults to 53 when omitted, exactly as lego does.
+func validateNameserver(ns string) error {
+	if ns == "" {
+		return fmt.Errorf("nameserver is empty")
+	}
+	if strings.ContainsAny(ns, " \t\r\n") {
+		return fmt.Errorf("nameserver %q contains whitespace", ns)
+	}
+	if strings.Contains(ns, "://") || strings.Contains(ns, "/") {
+		return fmt.Errorf("nameserver %q must be host[:port], not a URL", ns)
+	}
+
+	host, port, err := net.SplitHostPort(ns)
+	if err != nil {
+		// No port given: default to 53 the same way lego does, and re-check.
+		host, port, err = net.SplitHostPort(net.JoinHostPort(ns, "53"))
+		if err != nil {
+			return fmt.Errorf("nameserver %q is not a valid host[:port]: %w", ns, err)
+		}
+	}
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum < 1 || portNum > 65535 {
+		return fmt.Errorf("nameserver %q has invalid port %q", ns, port)
+	}
+
+	if net.ParseIP(host) == nil && !isHostname(host) {
+		return fmt.Errorf("nameserver %q has invalid host %q", ns, host)
+	}
+
+	return nil
+}
+
+// isHostname reports whether s looks like a DNS hostname: dot separated
+// alphanumeric-or-hyphen labels, optionally with a trailing root dot.
+func isHostname(s string) bool {
+	s = strings.TrimSuffix(s, ".")
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if label == "" || len(label) > 63 {
+			return false
+		}
+		if strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return false
+		}
+		for _, r := range label {
+			switch {
+			// '_' is not legal in a hostname per RFC 1123, but it is common in
+			// AD/legacy internal DNS names and both miekg/dns and lego query
+			// such names happily, so it is accepted here.
+			case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			default:
+				return false
+			}
+		}
+	}
+	return true
 }
 
 type S3Client struct {
@@ -184,6 +308,42 @@ type S3Client struct {
 	AccessKeyId     string `toml:"accessKeyId" json:"access_key_id,omitempty"`
 	AccessKeySecret string `toml:"accessKeySecret" json:"access_key_secret,omitempty"`
 	SessionToken    string `toml:"sessionToken" json:"session_token,omitempty"`
+
+	// ACL is the canned ACL sent with the challenge object. It is a pointer
+	// so that "unset" and "explicitly empty" are distinguishable:
+	//
+	//   - unset (nil): send [DefaultS3ACL], the ACL certdx has hardcoded
+	//     since v0.6.0. Existing ACL-based buckets keep working untouched.
+	//   - acl = "": send no ACL header at all, the only thing buckets with
+	//     ACLs disabled (the default since Apr 2023) accept.
+	//   - any other value: sent as-is.
+	ACL *string `toml:"acl" json:"acl,omitempty"`
+}
+
+// DefaultS3ACL is the canned ACL sent when [S3Client.ACL] is not set at all.
+// certdx up to v0.6.0 hardcoded it, so leaving acl out of the config must
+// keep producing publicly readable challenge objects.
+const DefaultS3ACL = "public-read"
+
+// ResolvedACL returns the canned ACL to send with the challenge object. An
+// empty return means "send no ACL header".
+func (c *S3Client) ResolvedACL() string {
+	if c == nil || c.ACL == nil {
+		return DefaultS3ACL
+	}
+	return *c.ACL
+}
+
+// s3CannedACLs is the set of AWS canned object ACLs accepted in
+// [S3Client.ACL]. The empty string (send no ACL) is handled separately.
+var s3CannedACLs = []string{
+	"private",
+	"public-read",
+	"public-read-write",
+	"authenticated-read",
+	"aws-exec-read",
+	"bucket-owner-read",
+	"bucket-owner-full-control",
 }
 
 type HttpProvider struct {
@@ -198,6 +358,18 @@ func (p *HttpProvider) Validate() error {
 	case HttpProviderTypeS3:
 		if p.S3 == nil {
 			return fmt.Errorf("HttpProvider S3: empty S3")
+		}
+		if p.S3.Bucket == "" || p.S3.URL == "" {
+			return fmt.Errorf("HttpProvider S3: empty bucket or url")
+		}
+		if p.S3.AccessKeyId == "" || p.S3.AccessKeySecret == "" {
+			return fmt.Errorf("HttpProvider S3: empty accessKeyId or accessKeySecret")
+		}
+		// acl unset keeps the historical default; acl = "" is the explicit
+		// "send no ACL header" opt-out. Anything else has to be a real canned
+		// ACL or S3 rejects the PutObject at challenge time.
+		if acl := p.S3.ACL; acl != nil && *acl != "" && !slices.Contains(s3CannedACLs, *acl) {
+			return fmt.Errorf("HttpProvider S3: unknown acl %q, expect one of %v or empty", *acl, s3CannedACLs)
 		}
 	// case HttpProviderTypeLocal:
 	// 	if p.Local == nil {
@@ -217,6 +389,13 @@ type HttpServerConfig struct {
 	Secure     bool     `toml:"secure" json:"secure,omitempty"`
 	Names      []string `toml:"names" json:"names,omitempty"`
 	Token      string   `toml:"token" json:"token,omitempty"`
+
+	// AllowAnonymous makes an empty token an explicit choice: without it an
+	// enabled token-auth server with no token is rejected.
+	AllowAnonymous bool `toml:"allowAnonymous" json:"allow_anonymous,omitempty"`
+	// AllowInsecureToken silences the warning about serving the token and the
+	// private keys over plain HTTP.
+	AllowInsecureToken bool `toml:"allowInsecureToken" json:"allow_insecure_token,omitempty"`
 }
 
 func (c *HttpServerConfig) Validate() error {
@@ -230,6 +409,23 @@ func (c *HttpServerConfig) Validate() error {
 
 	if c.Secure && len(c.Names) == 0 {
 		return fmt.Errorf("secure http server with no name")
+	}
+
+	switch c.AuthMethod {
+	case HTTP_AUTH_TOKEN:
+		if c.Token == "" && !c.AllowAnonymous {
+			return fmt.Errorf("[HttpServer] authMethod = %q with an empty token serves certificates to anyone, "+
+				"set token, or set allowAnonymous = true if that is intended", HTTP_AUTH_TOKEN)
+		}
+		if !c.Secure && !c.AllowInsecureToken {
+			logging.Warn("!!! [HttpServer] authMethod = %q with secure = false serves the token AND the private keys "+
+				"in cleartext. Set secure = true (or put the server behind TLS), "+
+				"or set allowInsecureToken = true to silence this warning !!!", HTTP_AUTH_TOKEN)
+		}
+	case HTTP_AUTH_MTLS:
+	default:
+		return fmt.Errorf("[HttpServer] unknown authMethod: %q, expected %q or %q",
+			c.AuthMethod, HTTP_AUTH_TOKEN, HTTP_AUTH_MTLS)
 	}
 
 	return nil
@@ -283,10 +479,11 @@ func (c *ServerConfig) SetDefault() {
 	}
 
 	c.HttpServer = HttpServerConfig{
-		Enabled: false,
-		Listen:  ":10001",
-		APIPath: "/",
-		Secure:  false,
+		Enabled:    false,
+		Listen:     ":10001",
+		APIPath:    "/",
+		AuthMethod: HTTP_AUTH_TOKEN,
+		Secure:     false,
 	}
 
 	c.GRPCSDSServer = GRPCServerConfig{

--- a/pkg/config/server_test.go
+++ b/pkg/config/server_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestACMEConfigValidateEmptyAllowedDomains(t *testing.T) {
@@ -184,9 +185,143 @@ func TestHttpProviderValidateS3Nil(t *testing.T) {
 }
 
 func TestHttpProviderValidateS3Valid(t *testing.T) {
-	p := &HttpProvider{Type: HttpProviderTypeS3, S3: &S3Client{}}
+	p := &HttpProvider{Type: HttpProviderTypeS3, S3: validS3Client()}
 	if err := p.Validate(); err != nil {
 		t.Fatalf("valid s3 provider: %v", err)
+	}
+}
+
+func validS3Client() *S3Client {
+	return &S3Client{
+		Bucket:          "cos-1000000000",
+		URL:             "https://cos.ap-beijing.myqcloud.com",
+		AccessKeyId:     "id",
+		AccessKeySecret: "secret",
+	}
+}
+
+func TestHttpProviderValidateS3MissingFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*S3Client)
+		wantMsg string
+	}{
+		{"no bucket", func(s *S3Client) { s.Bucket = "" }, "empty bucket or url"},
+		{"no url", func(s *S3Client) { s.URL = "" }, "empty bucket or url"},
+		{"no access key id", func(s *S3Client) { s.AccessKeyId = "" }, "empty accessKeyId or accessKeySecret"},
+		{"no access key secret", func(s *S3Client) { s.AccessKeySecret = "" }, "empty accessKeyId or accessKeySecret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s3 := validS3Client()
+			tc.mutate(s3)
+			p := &HttpProvider{Type: HttpProviderTypeS3, S3: s3}
+			err := p.Validate()
+			if err == nil {
+				t.Fatal("expected error on incomplete S3 config")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Fatalf("error wording drifted: %v", err)
+			}
+		})
+	}
+}
+
+// TestS3ClientResolvedACL locks the backward-compatible ACL semantics: an
+// absent acl key keeps sending the "public-read" certdx <= v0.6.0 hardcoded,
+// while an explicit empty acl opts out of the header entirely.
+func TestS3ClientResolvedACL(t *testing.T) {
+	empty := ""
+	private := "private"
+
+	cases := []struct {
+		name string
+		s3   *S3Client
+		want string
+	}{
+		{"unset keeps the historical public-read", &S3Client{}, DefaultS3ACL},
+		{"explicit empty sends no ACL", &S3Client{ACL: &empty}, ""},
+		{"explicit value is passed through", &S3Client{ACL: &private}, "private"},
+		{"nil receiver keeps the historical public-read", nil, DefaultS3ACL},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s3.ResolvedACL(); got != tc.want {
+				t.Errorf("ResolvedACL() = %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHttpProviderValidateS3ACL(t *testing.T) {
+	valid := []*string{nil, ptr(""), ptr("public-read"), ptr("private"), ptr("bucket-owner-full-control")}
+	for _, acl := range valid {
+		s3 := validS3Client()
+		s3.ACL = acl
+		p := &HttpProvider{Type: HttpProviderTypeS3, S3: s3}
+		if err := p.Validate(); err != nil {
+			t.Fatalf("acl %v should validate: %v", acl, err)
+		}
+	}
+
+	s3 := validS3Client()
+	s3.ACL = ptr("public_read")
+	p := &HttpProvider{Type: HttpProviderTypeS3, S3: s3}
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("expected error on unknown canned acl")
+	}
+	if !strings.Contains(err.Error(), "unknown acl") {
+		t.Fatalf("error wording drifted: %v", err)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestDnsProviderValidateNameservers(t *testing.T) {
+	base := DnsProvider{Type: DnsProviderTypeCloudflare, Email: "a@b.com", APIKey: "key"}
+
+	valid := [][]string{
+		nil,
+		{"8.8.8.8:53"},
+		{"1.1.1.1"},
+		{"dns.example.com:5353"},
+		{"[2001:4860:4860::8888]:53"},
+		{"2001:4860:4860::8888"},
+		// Underscore labels are illegal per RFC 1123 but common in AD /
+		// legacy internal DNS, and lego/miekg resolve them fine.
+		{"_dns.internal.example.com"},
+		{"ad_dc1.corp.example.com:53"},
+	}
+	for _, ns := range valid {
+		p := base
+		p.Nameservers = ns
+		if err := p.Validate(); err != nil {
+			t.Fatalf("valid nameservers %v: %v", ns, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"https://8.8.8.8",
+		"8.8.8.8:53 ",
+		"8.8.8.8 1.1.1.1",
+		"8.8.8.8:dns",
+		"8.8.8.8:0",
+		"8.8.8.8:99999",
+		"8.8.8.8:53/resolve",
+		"-bad-.example.com",
+	}
+	for _, ns := range invalid {
+		p := base
+		p.Nameservers = []string{ns}
+		err := p.Validate()
+		if err == nil {
+			t.Fatalf("expected error on nameserver %q", ns)
+		}
+		if !strings.Contains(err.Error(), "nameserver") {
+			t.Fatalf("error wording drifted for %q: %v", ns, err)
+		}
 	}
 }
 
@@ -209,12 +344,55 @@ func TestHttpServerConfigValidateDisabled(t *testing.T) {
 }
 
 func TestHttpServerConfigValidateAPIPathAutoPrefix(t *testing.T) {
-	c := &HttpServerConfig{Enabled: true, APIPath: "api/cert"}
+	c := &HttpServerConfig{Enabled: true, APIPath: "api/cert", AuthMethod: HTTP_AUTH_TOKEN, Token: "t"}
 	if err := c.Validate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if c.APIPath != "/api/cert" {
 		t.Errorf("APIPath not prefixed: got %s want /api/cert", c.APIPath)
+	}
+}
+
+func TestHttpServerConfigValidateAuthMethod(t *testing.T) {
+	cases := []struct {
+		name    string
+		c       HttpServerConfig
+		wantErr string
+	}{
+		{"empty", HttpServerConfig{Enabled: true, APIPath: "/", Token: "t"}, "unknown authMethod"},
+		{"typo", HttpServerConfig{Enabled: true, APIPath: "/", AuthMethod: "tokne", Token: "t"}, "unknown authMethod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if err == nil {
+				t.Fatal("expected error on bad authMethod")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error wording drifted: %v", err)
+			}
+		})
+	}
+
+	ok := &HttpServerConfig{Enabled: true, APIPath: "/", AuthMethod: HTTP_AUTH_MTLS}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("mtls auth method should validate: %v", err)
+	}
+}
+
+func TestHttpServerConfigValidateEmptyToken(t *testing.T) {
+	c := &HttpServerConfig{Enabled: true, APIPath: "/", AuthMethod: HTTP_AUTH_TOKEN}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error on token auth with empty token")
+	}
+	if !strings.Contains(err.Error(), "allowAnonymous") {
+		t.Fatalf("error wording drifted: %v", err)
+	}
+
+	c.AllowAnonymous = true
+	if err := c.Validate(); err != nil {
+		t.Fatalf("empty token with allowAnonymous should validate: %v", err)
 	}
 }
 
@@ -263,6 +441,112 @@ func TestServerConfigParseDurationInvalidRenewTimeLeft(t *testing.T) {
 	}
 }
 
+func TestServerConfigParseDurationRejectsNonPositive(t *testing.T) {
+	cases := []struct {
+		name          string
+		certLifeTime  string
+		renewTimeLeft string
+		wantMsg       string
+	}{
+		{"zero life time", "0s", "24h", "CertLifeTime must be positive"},
+		{"negative life time", "-168h", "24h", "CertLifeTime must be positive"},
+		{"zero renew time", "168h", "0s", "RenewTimeLeft must be positive"},
+		{"negative renew time", "168h", "-1h", "RenewTimeLeft must be positive"},
+		{"renew longer than life time", "24h", "168h", "must not be longer than CertLifeTime"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ServerConfig{}
+			c.SetDefault()
+			c.ACME.Provider = "r3"
+			c.ACME.CertLifeTime = tc.certLifeTime
+			c.ACME.RenewTimeLeft = tc.renewTimeLeft
+			err := c.parseDuration()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Fatalf("error wording drifted: %v", err)
+			}
+		})
+	}
+}
+
+// TestServerConfigParseDurationRenewEqualsCertLifeTime pins the "renew at half
+// life" setup (certLifeTime == renewTimeLeft): the cert is asked to live twice
+// certLifeTime and is renewed halfway through. Only renewTimeLeft strictly
+// longer than certLifeTime is rejected.
+func TestServerConfigParseDurationRenewEqualsCertLifeTime(t *testing.T) {
+	c := &ServerConfig{}
+	c.SetDefault()
+	c.ACME.Provider = "r3"
+	c.ACME.CertLifeTime = "720h"
+	c.ACME.RenewTimeLeft = "720h"
+	if err := c.parseDuration(); err != nil {
+		t.Fatalf("renewTimeLeft == certLifeTime should be accepted: %v", err)
+	}
+}
+
+func TestServerConfigParseDurationProviderMaxLifeTime(t *testing.T) {
+	c := &ServerConfig{}
+	c.SetDefault()
+	c.ACME.Provider = "google"
+	// 90d total is exactly the provider maximum.
+	c.ACME.CertLifeTime = "2136h"
+	c.ACME.RenewTimeLeft = "24h"
+	if err := c.parseDuration(); err != nil {
+		t.Fatalf("90d total should be accepted: %v", err)
+	}
+
+	c.ACME.CertLifeTime = "2137h"
+	err := c.parseDuration()
+	if err == nil {
+		t.Fatal("expected error on cert life time beyond provider maximum")
+	}
+	if !strings.Contains(err.Error(), "longer than") {
+		t.Fatalf("error wording drifted: %v", err)
+	}
+
+	// The mock provider mints its own certs, so the cap does not apply.
+	c.ACME.Provider = "mock"
+	c.ACME.CertLifeTime = "8760h"
+	if err := c.parseDuration(); err != nil {
+		t.Fatalf("mock provider should not be capped: %v", err)
+	}
+}
+
+// TestServerConfigParseDurationLongLifeTimeNonGoogle locks the backward-compat
+// fix: only Google gets the requested NotAfter on the wire, so an over-long
+// certLifeTime against Let's Encrypt keeps loading (the server clamps
+// ValidBefore against the issued leaf's real NotAfter at runtime).
+func TestServerConfigParseDurationLongLifeTimeNonGoogle(t *testing.T) {
+	for _, provider := range []string{"r3", "r3test"} {
+		t.Run(provider, func(t *testing.T) {
+			c := &ServerConfig{}
+			c.SetDefault()
+			c.ACME.Provider = provider
+			c.ACME.CertLifeTime = "8760h"
+			c.ACME.RenewTimeLeft = "168h"
+			if err := c.parseDuration(); err != nil {
+				t.Fatalf("non-google provider should not be hard-capped: %v", err)
+			}
+			if c.ACME.CertLifeTimeDuration != 8760*time.Hour {
+				t.Errorf("CertLifeTimeDuration: got %s", c.ACME.CertLifeTimeDuration)
+			}
+		})
+	}
+
+	// googletest is Google too, and must stay a hard error.
+	c := &ServerConfig{}
+	c.SetDefault()
+	c.ACME.Provider = "googletest"
+	c.ACME.CertLifeTime = "8760h"
+	c.ACME.RenewTimeLeft = "168h"
+	if err := c.parseDuration(); err == nil {
+		t.Fatal("expected googletest to reject an over-long cert life time")
+	}
+}
+
 func TestACMEConfigValidateUnsupportedChallengeType(t *testing.T) {
 	c := &ACMEConfig{
 		Provider:       "r3test",
@@ -296,5 +580,8 @@ func TestServerConfigSetDefault(t *testing.T) {
 	}
 	if c.GRPCSDSServer.Listen != ":10002" {
 		t.Errorf("default grpc listen: got %s want :10002", c.GRPCSDSServer.Listen)
+	}
+	if c.HttpServer.AuthMethod != HTTP_AUTH_TOKEN {
+		t.Errorf("default http authMethod: got %s want %s", c.HttpServer.AuthMethod, HTTP_AUTH_TOKEN)
 	}
 }

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -79,6 +79,63 @@ func Allowed(allowedList []string, toCheck string) bool {
 	return IsSubdomain(toCheck, allowedList)
 }
 
+// CertCovers reports whether a certificate issued for the single name entry
+// covers the domain name. Matching is case-insensitive and ignores a trailing
+// root dot. Unlike IsSubdomain, which treats every entry as a literal label
+// sequence, entry may be a wildcard:
+//
+//   - a literal entry ("example.com") covers itself and any subdomain of it,
+//     exactly as IsSubdomain does;
+//   - a wildcard entry ("*.example.com") covers the literal string itself and
+//     any name exactly one label below the base ("foo.example.com", but not
+//     "foo.bar.example.com"). It does NOT cover the base ("example.com"):
+//     certdx requests exactly the names a cert pack lists, so a pack of only
+//     ["*.example.com"] yields a certificate whose sole SAN is "*.example.com",
+//     which per RFC 6125 does not match the apex. Packs that serve the apex
+//     list it explicitly, and the exact-equality branch matches it.
+//
+// This agrees with certPackCovers in exec/caddytls for wildcard entries; the
+// literal-entry subdomain rule is the one deliberate difference (see the
+// comment there). IsSubdomain keeps its literal semantics for the server
+// allow-list gate; this helper is for callers matching against a configured
+// cert-pack domain list, where wildcards are meaningful.
+func CertCovers(name, entry string) bool {
+	n := normalizeName(name)
+	e := normalizeName(entry)
+	if n == e {
+		return true
+	}
+
+	base, isWildcard := strings.CutPrefix(e, "*.")
+	if !isWildcard {
+		return strings.HasSuffix(n, "."+e)
+	}
+	label, ok := strings.CutSuffix(n, "."+base)
+	return ok && label != "" && !strings.Contains(label, ".")
+}
+
+// CoveredByAny reports whether name is covered by at least one entry of
+// certList according to CertCovers.
+func CoveredByAny(certList []string, name string) bool {
+	for _, entry := range certList {
+		if CertCovers(name, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// AllCovered reports whether every name in toCheck is covered by certList
+// according to CertCovers. An empty toCheck is trivially covered.
+func AllCovered(certList []string, toCheck []string) bool {
+	for _, name := range toCheck {
+		if !CoveredByAny(certList, name) {
+			return false
+		}
+	}
+	return true
+}
+
 func normalizeName(name string) string {
 	return strings.ToLower(strings.TrimSuffix(name, "."))
 }

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -40,6 +40,91 @@ func TestAllAllowedUsesNormalizedSubdomainRules(t *testing.T) {
 	}
 }
 
+func TestIsSubdomainTreatsWildcardAsLiteralLabel(t *testing.T) {
+	// The server allow-list gate relies on this literal behavior; CertCovers is
+	// the wildcard-aware alternative.
+	if IsSubdomain("foo.example.com", []string{"*.example.com"}) {
+		t.Fatal("expected IsSubdomain to keep matching wildcard entries literally")
+	}
+}
+
+func TestCertCoversWildcardEntry(t *testing.T) {
+	covered := []string{
+		"foo.example.com",
+		"FOO.EXAMPLE.COM.",
+		"*.example.com",
+	}
+	for _, name := range covered {
+		if !CertCovers(name, "*.Example.COM.") {
+			t.Fatalf("expected %q to be covered by *.example.com", name)
+		}
+	}
+
+	notCovered := []string{
+		// The apex is not a SAN of a "*.example.com"-only cert (RFC 6125),
+		// so the wildcard entry must not claim to cover it. This mirrors
+		// certPackCovers in exec/caddytls.
+		"example.com",
+		"EXAMPLE.COM.",
+		"foo.bar.example.com",
+		"*.mm.example.com",
+		"attackerexample.com",
+		"example.com.attacker.net",
+	}
+	for _, name := range notCovered {
+		if CertCovers(name, "*.example.com") {
+			t.Fatalf("expected %q not to be covered by *.example.com", name)
+		}
+	}
+}
+
+func TestCertCoversLiteralEntryKeepsSubdomainBehavior(t *testing.T) {
+	if !CertCovers("a.b.example.com", "example.com") {
+		t.Fatal("expected literal entry to cover any subdomain")
+	}
+	if CertCovers("attackerevil.com", "evil.com") {
+		t.Fatal("expected literal entry to require a label boundary")
+	}
+}
+
+func TestAllCoveredMatchesShippedK8sConfigExample(t *testing.T) {
+	// config/client_k8s.toml ships this cert-pack domain list, and docs/tools.md
+	// documents secrets annotated with names under it.
+	certList := []string{"*.example.com", "*.mm.example.com"}
+
+	for _, toCheck := range [][]string{
+		{"foo.example.com"},
+		{"*.example.com", "bar.example.com"},
+		{"foo.mm.example.com", "bar.example.com"},
+	} {
+		if !AllCovered(certList, toCheck) {
+			t.Fatalf("expected %v to be covered by %v", toCheck, certList)
+		}
+	}
+
+	if AllCovered(certList, []string{"foo.example.com", "deep.nested.example.com"}) {
+		t.Fatal("expected a two-label-deep name to fall outside the wildcard")
+	}
+
+	// A wildcard-only pack does not carry the apex as a SAN, so it must not
+	// claim to cover it.
+	if AllCovered(certList, []string{"example.com"}) {
+		t.Fatal("expected a wildcard-only pack not to cover the apex")
+	}
+}
+
+func TestAllCoveredApexNeedsExplicitEntry(t *testing.T) {
+	// Packs that serve the apex list it alongside the wildcard; the
+	// exact-equality branch then matches it.
+	certList := []string{"example.com", "*.example.com"}
+
+	for _, name := range []string{"example.com", "EXAMPLE.COM.", "foo.example.com"} {
+		if !CoveredByAny(certList, name) {
+			t.Fatalf("expected %q to be covered by %v", name, certList)
+		}
+	}
+}
+
 func TestAsKeyCanonicalizesDomainSets(t *testing.T) {
 	first := AsKey([]string{"API.Example.COM.", "example.com", "api.example.com"})
 	second := AsKey([]string{"example.com.", "api.example.com"})

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -6,12 +6,28 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync/atomic"
 )
 
+// Both are read from every logging goroutine while SetLogger / SetDebug
+// may replace them concurrently (the Caddy plugin swaps the logger on
+// config reload), so they are accessed atomically.
 var (
-	debugEnabled bool
-	logger       = log.New(os.Stderr, "", log.LstdFlags)
+	debugEnabled atomic.Bool
+	logger       atomic.Pointer[log.Logger]
 )
+
+func init() {
+	logger.Store(log.New(os.Stderr, "", log.LstdFlags))
+}
+
+// currentLogger returns the active logger, never nil.
+func currentLogger() *log.Logger {
+	if l := logger.Load(); l != nil {
+		return l
+	}
+	return log.New(os.Stderr, "", log.LstdFlags)
+}
 
 // SetLogFile adds a log file as an additional output alongside stderr.
 func SetLogFile(logFilePath string) {
@@ -24,25 +40,29 @@ func SetLogFile(logFilePath string) {
 		return
 	}
 	Info("Log to file path: %s", logFilePath)
-	logger.SetOutput(io.MultiWriter(os.Stderr, logFile))
+	currentLogger().SetOutput(io.MultiWriter(os.Stderr, logFile))
 }
 
 // SetLogger replaces the underlying logger instance. Used by the Caddy
-// integration to route output through Caddy's zap logger.
+// integration to route output through Caddy's zap logger. A nil logger
+// is ignored so in-flight logging never panics.
 func SetLogger(l *log.Logger) {
-	logger = l
+	if l == nil {
+		return
+	}
+	logger.Store(l)
 }
 
 func SetDebug(enabled bool) {
-	debugEnabled = enabled
+	debugEnabled.Store(enabled)
 }
 
 func logf(prefix, format string, v ...any) {
-	logger.Printf("%s %s", prefix, fmt.Sprintf(format, v...))
+	currentLogger().Printf("%s %s", prefix, fmt.Sprintf(format, v...))
 }
 
 func Debug(format string, v ...any) {
-	if debugEnabled {
+	if debugEnabled.Load() {
 		logf("[DEB]", format, v...)
 	}
 }
@@ -53,7 +73,7 @@ func Warn(format string, v ...any)   { logf("[WRN]", format, v...) }
 func Error(format string, v ...any)  { logf("[ERR]", format, v...) }
 
 func Fatal(format string, v ...any) {
-	logger.Fatalf("[ERR] %s", fmt.Sprintf(format, v...))
+	currentLogger().Fatalf("[ERR] %s", fmt.Sprintf(format, v...))
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -2,20 +2,22 @@ package logging
 
 import (
 	"bytes"
+	"io"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 )
 
 func captureLogger(t *testing.T) (*bytes.Buffer, func()) {
 	t.Helper()
-	prev := logger
-	prevDebug := debugEnabled
+	prev := logger.Load()
+	prevDebug := debugEnabled.Load()
 	buf := &bytes.Buffer{}
-	logger = log.New(buf, "", 0)
+	logger.Store(log.New(buf, "", 0))
 	return buf, func() {
-		logger = prev
-		debugEnabled = prevDebug
+		logger.Store(prev)
+		debugEnabled.Store(prevDebug)
 	}
 }
 
@@ -23,7 +25,7 @@ func TestDebugSuppressedByDefault(t *testing.T) {
 	buf, restore := captureLogger(t)
 	defer restore()
 
-	debugEnabled = false
+	debugEnabled.Store(false)
 	Debug("should not appear")
 
 	if buf.Len() != 0 {
@@ -35,7 +37,7 @@ func TestDebugEnabledOutput(t *testing.T) {
 	buf, restore := captureLogger(t)
 	defer restore()
 
-	debugEnabled = true
+	debugEnabled.Store(true)
 	Debug("test %d", 42)
 
 	got := buf.String()
@@ -66,8 +68,8 @@ func TestSetDebugToggles(t *testing.T) {
 }
 
 func TestSetLoggerSwaps(t *testing.T) {
-	prev := logger
-	defer func() { logger = prev }()
+	prev := logger.Load()
+	defer func() { logger.Store(prev) }()
 
 	buf := &bytes.Buffer{}
 	SetLogger(log.New(buf, "", 0))
@@ -75,6 +77,51 @@ func TestSetLoggerSwaps(t *testing.T) {
 	Info("routed")
 	if !strings.Contains(buf.String(), "routed") {
 		t.Fatal("SetLogger did not swap output")
+	}
+}
+
+// TestConcurrentLogAndSetLogger reproduces the Caddy-reload data race:
+// goroutines logging while SetLogger / SetDebug swap the package state.
+// Fails under `go test -race` if the state is not accessed atomically.
+func TestConcurrentLogAndSetLogger(t *testing.T) {
+	_, restore := captureLogger(t)
+	defer restore()
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			Info("logging %d", i)
+			Debug("debug %d", i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			SetLogger(log.New(io.Discard, "", 0))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			SetDebug(i%2 == 0)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestSetLoggerIgnoresNil(t *testing.T) {
+	buf, restore := captureLogger(t)
+	defer restore()
+
+	SetLogger(nil)
+	Info("still routed")
+	if !strings.Contains(buf.String(), "still routed") {
+		t.Fatal("SetLogger(nil) dropped the active logger")
 	}
 }
 

--- a/pkg/mtls/mtls.go
+++ b/pkg/mtls/mtls.go
@@ -30,6 +30,7 @@ func parseBundle(path string) (tls.Certificate, *x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	rest := data
 	first := true
+	peers := 0
 	for {
 		var block *pem.Block
 		block, rest = pem.Decode(rest)
@@ -43,7 +44,17 @@ func parseBundle(path string) (tls.Certificate, *x509.CertPool, error) {
 			first = false
 			continue
 		}
-		pool.AppendCertsFromPEM(pem.EncodeToMemory(block))
+		if pool.AppendCertsFromPEM(pem.EncodeToMemory(block)) {
+			peers++
+		}
+	}
+
+	// An empty pool is never useful: it rejects every peer at handshake
+	// time with an opaque error. Fail at load instead, where the message
+	// can point at the bundle.
+	if peers == 0 {
+		return tls.Certificate{}, nil, fmt.Errorf(
+			"no CA certificate in mtls bundle %s: the bundle must contain the issuing CA certificate after the entity cert and key", path)
 	}
 
 	return cert, pool, nil

--- a/pkg/mtls/mtls_test.go
+++ b/pkg/mtls/mtls_test.go
@@ -1,0 +1,259 @@
+package mtls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testChain is an in-memory CA + leaf pair used to assemble bundles.
+type testChain struct {
+	caCert   *x509.Certificate
+	caPEM    []byte
+	leafPEM  []byte
+	leafKey  []byte
+	leafCert *x509.Certificate
+}
+
+func newTestChain(t *testing.T) *testChain {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("self-sign CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test leaf"},
+		DNSNames:     []string{"localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth,
+		},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("sign leaf: %v", err)
+	}
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+
+	return &testChain{
+		caCert:   caCert,
+		caPEM:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+		leafPEM:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}),
+		leafKey:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+		leafCert: leafCert,
+	}
+}
+
+// writeBundle writes the concatenated PEM blocks to a temp file and
+// returns its path.
+func writeBundle(t *testing.T, blocks ...[]byte) string {
+	t.Helper()
+	var buf []byte
+	for _, b := range blocks {
+		buf = append(buf, b...)
+	}
+	p := filepath.Join(t.TempDir(), "bundle.pem")
+	if err := os.WriteFile(p, buf, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return p
+}
+
+// expectedPool is the pool a well-formed bundle must produce.
+func expectedPool(c *testChain) *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(c.caCert)
+	return pool
+}
+
+func TestParseBundleWellFormed(t *testing.T) {
+	c := newTestChain(t)
+	path := writeBundle(t, c.leafPEM, c.leafKey, c.caPEM)
+
+	cert, pool, err := parseBundle(path)
+	if err != nil {
+		t.Fatalf("parseBundle: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("no leaf certificate in tls.Certificate")
+	}
+	if string(cert.Certificate[0]) != string(c.leafCert.Raw) {
+		t.Fatal("tls.Certificate leaf is not the first CERTIFICATE block")
+	}
+	if !pool.Equal(expectedPool(c)) {
+		t.Fatal("peer pool does not contain exactly the CA certificate")
+	}
+	if _, err := c.leafCert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		t.Fatalf("leaf does not verify against the parsed pool: %v", err)
+	}
+}
+
+func TestParseBundleKeyFirst(t *testing.T) {
+	c := newTestChain(t)
+	// The key may sit in any position; the first CERTIFICATE block is
+	// still the entity cert and the rest form the peer pool.
+	path := writeBundle(t, c.leafKey, c.leafPEM, c.caPEM)
+
+	cert, pool, err := parseBundle(path)
+	if err != nil {
+		t.Fatalf("parseBundle: %v", err)
+	}
+	if string(cert.Certificate[0]) != string(c.leafCert.Raw) {
+		t.Fatal("leaf mismatch when the key comes first")
+	}
+	if !pool.Equal(expectedPool(c)) {
+		t.Fatal("peer pool does not contain exactly the CA certificate")
+	}
+}
+
+func TestParseBundleMissingCA(t *testing.T) {
+	c := newTestChain(t)
+	path := writeBundle(t, c.leafPEM, c.leafKey)
+
+	if _, _, err := parseBundle(path); err == nil {
+		t.Fatal("expected an error for a bundle with no CA section")
+	}
+}
+
+func TestParseBundleReorderedCAFirst(t *testing.T) {
+	c := newTestChain(t)
+	// CA first means tls.X509KeyPair pairs the CA cert with the leaf
+	// key, which must fail at load rather than at handshake time.
+	path := writeBundle(t, c.caPEM, c.leafPEM, c.leafKey)
+
+	if _, _, err := parseBundle(path); err == nil {
+		t.Fatal("expected an error when the CA precedes the entity cert")
+	}
+}
+
+func TestParseBundleIgnoresExtraPEMTypes(t *testing.T) {
+	c := newTestChain(t)
+	noise := pem.EncodeToMemory(&pem.Block{Type: "DH PARAMETERS", Bytes: []byte("ignored")})
+	trust := pem.EncodeToMemory(&pem.Block{Type: "TRUSTED CERTIFICATE", Bytes: c.caCert.Raw})
+	path := writeBundle(t, noise, c.leafPEM, trust, c.leafKey, c.caPEM)
+
+	_, pool, err := parseBundle(path)
+	if err != nil {
+		t.Fatalf("parseBundle: %v", err)
+	}
+	if !pool.Equal(expectedPool(c)) {
+		t.Fatal("non-CERTIFICATE blocks must not enter the peer pool")
+	}
+}
+
+func TestParseBundleMissingFile(t *testing.T) {
+	if _, _, err := parseBundle(filepath.Join(t.TempDir(), "absent.pem")); err == nil {
+		t.Fatal("expected an error for a missing bundle file")
+	}
+}
+
+func TestParseBundleGarbage(t *testing.T) {
+	path := writeBundle(t, []byte("not pem at all\n"))
+	if _, _, err := parseBundle(path); err == nil {
+		t.Fatal("expected an error for a non-PEM bundle")
+	}
+}
+
+func TestLoadServer(t *testing.T) {
+	c := newTestChain(t)
+	path := writeBundle(t, c.leafPEM, c.leafKey, c.caPEM)
+
+	cfg, err := LoadServer(path)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Errorf("ClientAuth = %v, want RequireAndVerifyClientCert", cfg.ClientAuth)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 || cfg.MaxVersion != tls.VersionTLS13 {
+		t.Errorf("TLS version pinning: min=%x max=%x, want both TLS1.3", cfg.MinVersion, cfg.MaxVersion)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates length = %d, want 1", len(cfg.Certificates))
+	}
+	if cfg.ClientCAs == nil || !cfg.ClientCAs.Equal(expectedPool(c)) {
+		t.Error("ClientCAs does not contain exactly the CA certificate")
+	}
+	if cfg.RootCAs != nil {
+		t.Error("server config must not set RootCAs")
+	}
+}
+
+func TestLoadClient(t *testing.T) {
+	c := newTestChain(t)
+	path := writeBundle(t, c.leafPEM, c.leafKey, c.caPEM)
+
+	cfg, err := LoadClient(path)
+	if err != nil {
+		t.Fatalf("LoadClient: %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 || cfg.MaxVersion != tls.VersionTLS13 {
+		t.Errorf("TLS version pinning: min=%x max=%x, want both TLS1.3", cfg.MinVersion, cfg.MaxVersion)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates length = %d, want 1", len(cfg.Certificates))
+	}
+	if cfg.RootCAs == nil || !cfg.RootCAs.Equal(expectedPool(c)) {
+		t.Error("RootCAs does not contain exactly the CA certificate")
+	}
+	if cfg.ClientCAs != nil {
+		t.Error("client config must not set ClientCAs")
+	}
+}
+
+func TestLoadServerAndClientRejectBundleWithoutCA(t *testing.T) {
+	c := newTestChain(t)
+	path := writeBundle(t, c.leafPEM, c.leafKey)
+
+	if _, err := LoadServer(path); err == nil {
+		t.Error("LoadServer accepted a bundle with no CA section")
+	}
+	if _, err := LoadClient(path); err == nil {
+		t.Error("LoadClient accepted a bundle with no CA section")
+	}
+}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -130,7 +131,28 @@ func CACounterPath() (string, error) {
 	return filepath.Join(dir, "counter.txt"), nil
 }
 
+// checkFilenameComponent rejects values that would escape the directory
+// they are interpolated into. Anything that is not a plain filename
+// component — a path separator, "." or ".." — is an error rather than a
+// silently relocated file.
+func checkFilenameComponent(kind, v string) error {
+	if v == "" {
+		return fmt.Errorf("empty %s", kind)
+	}
+	if strings.ContainsAny(v, `/\`) || strings.ContainsRune(v, os.PathSeparator) ||
+		strings.ContainsRune(v, 0) {
+		return fmt.Errorf("invalid %s %q: must not contain a path separator", kind, v)
+	}
+	if v == "." || v == ".." || filepath.Base(v) != v {
+		return fmt.Errorf("invalid %s %q: must be a plain filename component", kind, v)
+	}
+	return nil
+}
+
 func MtlsBundlePath(name string) (string, error) {
+	if err := checkFilenameComponent("bundle name", name); err != nil {
+		return "", err
+	}
 	dir, err := MtlsDir()
 	if err != nil {
 		return "", err
@@ -139,6 +161,12 @@ func MtlsBundlePath(name string) (string, error) {
 }
 
 func ACMEPrivateKey(email, acmeProvider string) (string, error) {
+	if err := checkFilenameComponent("account email", email); err != nil {
+		return "", err
+	}
+	if err := checkFilenameComponent("acme provider", acmeProvider); err != nil {
+		return "", err
+	}
 	root, err := stateRoot()
 	if err != nil {
 		return "", err

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -83,6 +83,57 @@ func TestMtlsBundlePathName(t *testing.T) {
 	}
 }
 
+func TestACMEPrivateKeyRejectsTraversal(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "data")
+	withDataDir(t, override)
+
+	cases := []struct{ email, provider string }{
+		{"../../etc/passwd", "r3"},
+		{"a/b@example.com", "r3"},
+		{"u@example.com", "../r3"},
+		{"u@example.com", "sub/r3"},
+		{"..", "r3"},
+		{".", "r3"},
+		{"", "r3"},
+		{"u@example.com", ""},
+		{"u\x00@example.com", "r3"},
+	}
+	for _, c := range cases {
+		p, err := ACMEPrivateKey(c.email, c.provider)
+		if err == nil {
+			t.Errorf("ACMEPrivateKey(%q, %q) = %q, want error", c.email, c.provider, p)
+		}
+	}
+}
+
+func TestACMEPrivateKeyStaysInsidePrivateDir(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "data")
+	withDataDir(t, override)
+
+	// Plain-but-unusual local parts must keep working and must resolve
+	// inside private/.
+	for _, email := range []string{"u@example.com", "u+tag@example.com", "u.name@example.com"} {
+		p, err := ACMEPrivateKey(email, "r3")
+		if err != nil {
+			t.Fatalf("ACMEPrivateKey(%q): %v", email, err)
+		}
+		if want := filepath.Join(override, "private"); filepath.Dir(p) != want {
+			t.Errorf("key for %q escaped %s: %s", email, want, p)
+		}
+	}
+}
+
+func TestMtlsBundlePathRejectsTraversal(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "data")
+	withDataDir(t, override)
+
+	for _, name := range []string{"../ca", "a/b", "..", "", "."} {
+		if p, err := MtlsBundlePath(name); err == nil {
+			t.Errorf("MtlsBundlePath(%q) = %q, want error", name, p)
+		}
+	}
+}
+
 func TestMtlsCAAndCounterPath(t *testing.T) {
 	override := filepath.Join(t.TempDir(), "data")
 	withDataDir(t, override)

--- a/pkg/server/cert_entry.go
+++ b/pkg/server/cert_entry.go
@@ -2,9 +2,26 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
 	"sync"
 
 	"pkg.para.party/certdx/pkg/domain"
+	"pkg.para.party/certdx/pkg/logging"
+)
+
+var (
+	// ErrNoDomains is returned when a cert is requested for an empty domain
+	// set. Such a request can never produce a certificate, so it is rejected
+	// at the cache boundary instead of creating a useless entry.
+	ErrNoDomains = errors.New("no domains requested")
+
+	// ErrCacheFull is returned when a new cert pack would exceed the
+	// configured cache-entry cap. Wrapped with the offending domains.
+	ErrCacheFull = errors.New("cert cache entry limit reached")
 )
 
 // certEntry holds one domain bundle's cached cert, the "renewed" broadcast
@@ -23,6 +40,10 @@ import (
 //     cancel it via cancelRenew.
 type certEntry struct {
 	domains []string
+	// canonical is domains in the same canonical form domain.AsKey hashes.
+	// Cache lookups compare against it so a Key collision can never hand
+	// back a cert pack whose domain set differs from the requested one.
+	canonical []string
 
 	renewMu sync.Mutex // serializes Renew (held during ACME)
 
@@ -35,40 +56,105 @@ type certEntry struct {
 	subscribing int64
 }
 
+// certCache maps a domain.Key to the cert packs stored under it. The value is
+// a slice because domain.Key is a 64-bit hash: two different domain sets can
+// collide, and serving one set's cert to the other would be a mis-issuance, so
+// colliding packs live side by side and are told apart by their canonical
+// domain lists.
 type certCache struct {
-	entries map[domain.Key]*certEntry
+	entries map[domain.Key][]*certEntry
 	mutex   sync.Mutex
+
+	// maxEntries caps the number of distinct cert packs held. Zero (the
+	// default) means unlimited, which preserves the historical behavior for
+	// configs that don't set it.
+	maxEntries int
+	size       int
 }
 
 func makeCertCache() certCache {
 	return certCache{
-		entries: make(map[domain.Key]*certEntry),
+		entries: make(map[domain.Key][]*certEntry),
 	}
 }
 
 func newCertEntry(domains []string) *certEntry {
 	return &certEntry{
-		domains: domains,
-		updated: make(chan struct{}),
+		domains:   domains,
+		canonical: canonicalDomains(domains),
+		updated:   make(chan struct{}),
 	}
 }
 
-func (c *certCache) getNoLock(domains []string) *certEntry {
+// canonicalDomains returns domains in the canonical form domain.AsKey hashes:
+// lower-cased, trailing root dot trimmed, empty names dropped, de-duplicated
+// and sorted. Two slices describing the same domain set canonicalize equal.
+func canonicalDomains(domains []string) []string {
+	canon := make([]string, 0, len(domains))
+	seen := make(map[string]struct{}, len(domains))
+	for _, d := range domains {
+		d = strings.ToLower(strings.TrimSuffix(d, "."))
+		if d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		canon = append(canon, d)
+	}
+	sort.Strings(canon)
+	return canon
+}
+
+// getNoLock returns the entry for domains, creating it if absent. The caller
+// must hold c.mutex. It fails on an empty domain set and when a new entry
+// would exceed maxEntries; on a Key hit whose stored domain set differs, a
+// separate entry is created rather than handing back the wrong cert pack.
+func (c *certCache) getNoLock(domains []string) (*certEntry, error) {
+	canon := canonicalDomains(domains)
+	if len(canon) == 0 {
+		return nil, ErrNoDomains
+	}
+
 	entryKey := domain.AsKey(domains)
-	entry, ok := c.entries[entryKey]
-	if ok {
-		return entry
+	stored := c.entries[entryKey]
+	for _, entry := range stored {
+		if slices.Equal(entry.canonical, canon) {
+			return entry, nil
+		}
+	}
+	if len(stored) != 0 {
+		logging.Warn("Cert cache key collision: requested %v does not match stored %v, using a separate entry",
+			domains, stored[0].domains)
 	}
 
-	entry = newCertEntry(domains)
-	c.entries[entryKey] = entry
-	return entry
+	if c.maxEntries > 0 && c.size >= c.maxEntries {
+		return nil, fmt.Errorf("%w (%d), refusing cert pack %v", ErrCacheFull, c.maxEntries, domains)
+	}
+
+	entry := newCertEntry(domains)
+	c.entries[entryKey] = append(stored, entry)
+	c.size++
+	return entry, nil
 }
 
-func (c *certCache) get(domains []string) *certEntry {
+func (c *certCache) get(domains []string) (*certEntry, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	return c.getNoLock(domains)
+}
+
+// setMaxEntries applies the configured cap on distinct cert packs. Zero or
+// negative means unlimited. Existing entries are never evicted; the cap only
+// refuses new ones.
+func (c *certCache) setMaxEntries(max int) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if max < 0 {
+		max = 0
+	}
+	c.maxEntries = max
 }
 
 // Snapshot returns the current cert and the version that minted it. The pair

--- a/pkg/server/cert_entry_test.go
+++ b/pkg/server/cert_entry_test.go
@@ -2,9 +2,13 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
+
+	"pkg.para.party/certdx/pkg/domain"
 )
 
 func makeValidTestEntry() *certEntry {
@@ -199,18 +203,117 @@ func TestWaitForUpdateRespectsContextCancel(t *testing.T) {
 	}
 }
 
+func mustGet(t *testing.T, cc *certCache, domains []string) *certEntry {
+	t.Helper()
+	entry, err := cc.get(domains)
+	if err != nil {
+		t.Fatalf("get(%v): %v", domains, err)
+	}
+	return entry
+}
+
 func TestCertCacheGetCreatesAndDeduplicates(t *testing.T) {
 	cc := makeCertCache()
 
-	e1 := cc.get([]string{"a.com"})
-	e2 := cc.get([]string{"a.com"})
+	e1 := mustGet(t, &cc, []string{"a.com"})
+	e2 := mustGet(t, &cc, []string{"a.com"})
 	if e1 != e2 {
 		t.Fatal("get returned different entries for the same domains")
 	}
 
-	e3 := cc.get([]string{"b.com"})
+	e3 := mustGet(t, &cc, []string{"b.com"})
 	if e1 == e3 {
 		t.Fatal("get returned the same entry for different domains")
+	}
+}
+
+func TestCertCacheGetCanonicalizesDomains(t *testing.T) {
+	cc := makeCertCache()
+
+	e1 := mustGet(t, &cc, []string{"A.com.", "b.com"})
+	e2 := mustGet(t, &cc, []string{"b.com.", "a.com", "a.com"})
+	if e1 != e2 {
+		t.Fatal("equivalent domain sets got different entries")
+	}
+	if cc.size != 1 {
+		t.Fatalf("cache size = %d, want 1", cc.size)
+	}
+}
+
+func TestCertCacheRejectsEmptyDomains(t *testing.T) {
+	cc := makeCertCache()
+
+	for _, domains := range [][]string{nil, {}, {""}, {".", ""}} {
+		entry, err := cc.get(domains)
+		if !errors.Is(err, ErrNoDomains) {
+			t.Fatalf("get(%v): err = %v, want ErrNoDomains", domains, err)
+		}
+		if entry != nil {
+			t.Fatalf("get(%v) returned an entry", domains)
+		}
+	}
+	if cc.size != 0 {
+		t.Fatalf("cache size = %d, want 0", cc.size)
+	}
+}
+
+// A domain.Key collision must never hand back a pack covering other domains.
+// The collision is simulated by planting a foreign entry under the requested
+// key, since FNV-64 collisions can't be conjured on demand.
+func TestCertCacheKeyCollisionKeepsPacksDistinct(t *testing.T) {
+	cc := makeCertCache()
+
+	key := domain.AsKey([]string{"mine.com"})
+	foreign := newCertEntry([]string{"other.com"})
+	cc.entries[key] = []*certEntry{foreign}
+	cc.size = 1
+
+	entry := mustGet(t, &cc, []string{"mine.com"})
+	if entry == foreign {
+		t.Fatal("returned the colliding entry for a different domain set")
+	}
+	if len(entry.domains) != 1 || entry.domains[0] != "mine.com" {
+		t.Fatalf("entry domains: %v", entry.domains)
+	}
+	// Both packs live side by side under the colliding key, and the
+	// pre-existing one is untouched.
+	stored := cc.entries[key]
+	if len(stored) != 2 || stored[0] != foreign || stored[1] != entry {
+		t.Fatalf("entries under key: %d, want the foreign entry plus the new one", len(stored))
+	}
+	if again := mustGet(t, &cc, []string{"mine.com"}); again != entry {
+		t.Fatal("second lookup did not return the same entry")
+	}
+}
+
+func TestCertCacheMaxEntriesRefusesNewPacks(t *testing.T) {
+	cc := makeCertCache()
+	cc.setMaxEntries(2)
+
+	first := mustGet(t, &cc, []string{"a.com"})
+	mustGet(t, &cc, []string{"b.com"})
+
+	entry, err := cc.get([]string{"c.com"})
+	if !errors.Is(err, ErrCacheFull) {
+		t.Fatalf("err = %v, want ErrCacheFull", err)
+	}
+	if entry != nil {
+		t.Fatal("entry returned past the cap")
+	}
+	// Already-known packs keep working.
+	if again := mustGet(t, &cc, []string{"a.com"}); again != first {
+		t.Fatal("existing entry lost after hitting the cap")
+	}
+}
+
+func TestCertCacheZeroMaxEntriesIsUnlimited(t *testing.T) {
+	cc := makeCertCache()
+
+	for i := range 50 {
+		mustGet(t, &cc, []string{fmt.Sprintf("d%d.com", i)})
+	}
+	if cc.size != 50 {
+		t.Fatalf("cache size = %d, want 50", cc.size)
 	}
 }
 

--- a/pkg/server/cert_store.go
+++ b/pkg/server/cert_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"pkg.para.party/certdx/pkg/domain"
@@ -68,17 +69,62 @@ func (s *CertStore) Load() error {
 	return nil
 }
 
+// save persists the whole store atomically: the JSON is written and fsynced
+// to a temp file next to cache.json and then renamed over it, so a crash
+// mid-write leaves the previous store intact instead of an empty file.
+// Mirrors the client's writeCertKeyPairAtomic.
 func (s *CertStore) save() error {
 	jsonBytes, err := json.Marshal(s.entries)
 	if err != nil {
 		return fmt.Errorf("marshal cert store: %w", err)
 	}
 
-	if err := os.WriteFile(s.path, jsonBytes, 0o600); err != nil {
+	tmpPath := s.path + ".tmp"
+	if err := writeFileSynced(tmpPath, jsonBytes, 0o600); err != nil {
 		return fmt.Errorf("write cert store: %w", err)
 	}
+	defer func() { _ = os.Remove(tmpPath) }() // no-op after rename succeeds
+
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("replace cert store: %w", err)
+	}
+	syncDir(filepath.Dir(s.path))
 
 	return nil
+}
+
+// writeFileSynced writes data to path with the given permissions and fsyncs
+// the file before returning, so the rename that follows can't expose a file
+// whose contents never reached the disk.
+func writeFileSynced(path string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// syncDir fsyncs a directory so a rename inside it is durable. Failures are
+// only logged: the store itself is already written, and some filesystems
+// don't allow opening a directory for sync.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		logging.Debug("Sync cert store directory failed: %s", err)
+		return
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		logging.Debug("Sync cert store directory failed: %s", err)
+	}
 }
 
 func (s *CertStore) saveEntry(fe *certStoreEntry) error {

--- a/pkg/server/cert_store_test.go
+++ b/pkg/server/cert_store_test.go
@@ -120,6 +120,47 @@ func TestCertStoreSaveAndLoad(t *testing.T) {
 	}
 }
 
+// save must go through a temp file + rename so a crash mid-write can't leave
+// cache.json truncated, and must not leave the temp file behind.
+func TestCertStoreSaveIsAtomic(t *testing.T) {
+	cs := makeTempCertStore(t)
+
+	if err := os.WriteFile(cs.path, []byte(`{"1":{"domains":["old.com"],"cert":{}}}`), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	entry := &certStoreEntry{
+		Domains: []string{"new.com"},
+		Cert:    CertT{FullChain: []byte("fc"), Key: []byte("k"), ValidBefore: time.Now().Add(time.Hour)},
+	}
+	if err := cs.saveEntry(entry); err != nil {
+		t.Fatalf("saveEntry: %v", err)
+	}
+
+	if _, err := os.Stat(cs.path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temp file left behind: %v", err)
+	}
+
+	var reloaded map[domain.Key]*certStoreEntry
+	b, err := os.ReadFile(cs.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := json.Unmarshal(b, &reloaded); err != nil {
+		t.Fatalf("store is not valid JSON after save: %v", err)
+	}
+	if _, ok := reloaded[domain.AsKey([]string{"new.com"})]; !ok {
+		t.Fatal("saved entry missing from the store file")
+	}
+	st, err := os.Stat(cs.path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("perm: got %o want 0600", mode)
+	}
+}
+
 func TestCertStoreListenUpdatePersists(t *testing.T) {
 	cs := makeTempCertStore(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,13 @@ import (
 // httpShutdownTimeout caps how long graceful shutdown of the HTTP API
 // waits for in-flight requests to drain before forcing a close.
 const httpShutdownTimeout = 30 * time.Second
+
+// httpCertWaitTimeout caps how long a cert request waits for an in-flight
+// issuance to land before answering 503. It only applies when another
+// subscriber (the SDS path, the HTTPS listener, ...) already has a renewer
+// running for the requested pack, so the request piggybacks on that
+// issuance rather than starting a second one.
+const httpCertWaitTimeout = 30 * time.Second
 
 func (s *CertDXServer) apiHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == s.Config.HttpServer.APIPath {
@@ -56,7 +64,12 @@ func (s *CertDXServer) checkAuthorizationToken(r *http.Request) bool {
 	auth := r.Header.Get("Authorization")
 	if auth != "" && strings.HasPrefix(auth, "Token ") {
 		token := strings.TrimPrefix(auth, "Token ")
-		if token == s.Config.HttpServer.Token {
+		// Constant-time compare so the response latency doesn't leak how
+		// many leading bytes of the token were guessed right. The length
+		// check keeps ConstantTimeCompare from short-circuiting on it.
+		expected := s.Config.HttpServer.Token
+		if len(token) == len(expected) &&
+			subtle.ConstantTimeCompare([]byte(token), []byte(expected)) == 1 {
 			return true
 		}
 	}
@@ -68,58 +81,89 @@ func (s *CertDXServer) checkAuthorizationToken(r *http.Request) bool {
 
 func (s *CertDXServer) handleCertReq(w *http.ResponseWriter, r *http.Request) {
 	var req api.HttpCertReq
-	var resp []byte
-	var cachedCert *certEntry
-	var cert CertT
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		if err == io.EOF {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
 			err = fmt.Errorf("no body")
 		}
-		goto ERR
+		// A body we can't parse is the caller's fault, not ours; 500 stays
+		// reserved for server-side (ACME) failures.
+		logging.Warn("Malformed http cert request from %s: %s", r.RemoteAddr, err)
+		http.Error(*w, "", http.StatusBadRequest)
+		return
+	}
+
+	// An empty domain set would otherwise pass the allow-list check
+	// vacuously and have the server issue for nothing.
+	if len(req.Domains) == 0 {
+		logging.Warn("Http cert request from %s carries no domains", r.RemoteAddr)
+		http.Error(*w, "", http.StatusBadRequest)
+		return
 	}
 
 	if !domain.AllAllowed(s.Config.ACME.AllowedDomains, req.Domains) {
-		// Wrap the sentinel so the response handler below can branch on
-		// errors.Is — same pattern as the SDS path, instead of two
-		// separate "domains not allowed" code sites.
-		err = fmt.Errorf("domains %v: %w", req.Domains, domain.ErrNotAllowed)
-		goto ERR
+		logging.Warn("Requested domains not allowed: %v (%s)", req.Domains, domain.ErrNotAllowed)
+		(*w).Header().Set("Content-Type", "application/json")
+		(*w).Write([]byte(`{ "err": "Domains not allowed" }`))
+		return
 	}
 
-	cachedCert = s.certCache.get(req.Domains)
-	if !s.isSubscribing(cachedCert) {
-		_, err = s.renew(r.Context(), cachedCert, false)
-		if err != nil {
-			goto ERR
+	cachedCert, err := s.certCache.get(req.Domains)
+	if err != nil {
+		if errors.Is(err, ErrNoDomains) {
+			logging.Warn("Http cert request from %s carries no usable domains: %v", r.RemoteAddr, req.Domains)
+			http.Error(*w, "", http.StatusBadRequest)
+			return
 		}
+		logging.Error("Handle http cert request failed: %s", err)
+		http.Error(*w, "", http.StatusServiceUnavailable)
+		return
 	}
 
-	cert = cachedCert.Cert()
-	resp, err = json.Marshal(&api.HttpCertResp{
+	cert, seen := cachedCert.Snapshot()
+	if !cert.IsValid() {
+		if s.isSubscribing(cachedCert) {
+			// A renewer already owns this pack — wait for it to publish
+			// instead of racing a second ACME obtain against it. The entry
+			// may be subscribed but not yet issued, in which case its cert
+			// is still the zero value.
+			waitCtx, cancel := context.WithTimeout(r.Context(), httpCertWaitTimeout)
+			cachedCert.WaitForUpdate(waitCtx, seen)
+			cancel()
+		} else if _, err := s.renew(r.Context(), cachedCert, false); err != nil {
+			logging.Error("Handle http cert request failed: %s", err)
+			http.Error(*w, "", http.StatusInternalServerError)
+			return
+		}
+		cert = cachedCert.Cert()
+	}
+
+	// Never answer 200 with an empty cert: the client writes whatever it
+	// gets straight to disk and would clobber a working certificate with
+	// zero-length files. Absent material is the only "no cert yet" signal
+	// this guard keys on — expiry is the renewer's business, and answering
+	// 503 for a cert we do hold would leave the client with nothing at all
+	// instead of a cert it can keep using while the renewal lands.
+	if len(cert.FullChain) == 0 || len(cert.Key) == 0 {
+		logging.Warn("No cert for %v available yet, asked by: %s", cachedCert.domains, r.RemoteAddr)
+		http.Error(*w, "", http.StatusServiceUnavailable)
+		return
+	}
+
+	resp, err := json.Marshal(&api.HttpCertResp{
 		RenewTimeLeft: s.Config.ACME.RenewTimeLeftDuration,
 		FullChain:     cert.FullChain,
 		Key:           cert.Key,
 	})
 	if err != nil {
-		goto ERR
+		logging.Error("Handle http cert request failed: %s", err)
+		http.Error(*w, "", http.StatusInternalServerError)
+		return
 	}
 
 	(*w).Header().Set("Content-Type", "application/json")
 	(*w).Write(resp)
 	logging.Info("Http sent cert: %v to: %s", cachedCert.domains, r.RemoteAddr)
-	return
-
-ERR:
-	if errors.Is(err, domain.ErrNotAllowed) {
-		logging.Warn("Requested domains not allowed: %v", req.Domains)
-		(*w).Header().Set("Content-Type", "application/json")
-		(*w).Write([]byte(`{ "err": "Domains not allowed" }`))
-		return
-	}
-	logging.Error("Handle http cert request failed: %s", err)
-	http.Error(*w, "", http.StatusInternalServerError)
 }
 
 // runHTTPServer starts a graceful-shutdown watcher tied to ctx and then
@@ -147,7 +191,10 @@ func runHTTPServer(ctx context.Context, server *http.Server, listen func() error
 // iteration sub-ctx fires on either rootCtx or a fresh cert; runHTTPServer
 // drives the listener and the graceful shutdown for that iteration.
 func (s *CertDXServer) serveHttps(handler http.Handler) error {
-	entry := s.certCache.get(s.Config.HttpServer.Names)
+	entry, err := s.certCache.get(s.Config.HttpServer.Names)
+	if err != nil {
+		return fmt.Errorf("HTTPS listener certificate %v: %w", s.Config.HttpServer.Names, err)
+	}
 	s.subscribe(entry)
 	defer s.release(entry)
 

--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"pkg.para.party/certdx/pkg/acme"
 	"pkg.para.party/certdx/pkg/api"
 )
 
@@ -97,14 +99,168 @@ func TestApiWithTokenHandlerRejectsInvalidToken(t *testing.T) {
 	}
 }
 
+func TestCheckAuthorizationTokenLengthMismatch(t *testing.T) {
+	s := makeTestServer("secret123", "/", nil)
+	for _, token := range []string{"secret12", "secret1234", ""} {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.Header.Set("Authorization", "Token "+token)
+		if s.checkAuthorizationToken(req) {
+			t.Fatalf("token %q should not authorize", token)
+		}
+	}
+}
+
 func TestHandleCertReqEmptyBody(t *testing.T) {
 	s := makeTestServer("", "/", []string{"example.com"})
 	req := httptest.NewRequest("POST", "/", nil)
 	w := httptest.NewRecorder()
 	var rw http.ResponseWriter = w
 	s.handleCertReq(&rw, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("empty body: got %d want %d", w.Code, http.StatusInternalServerError)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("empty body: got %d want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCertReqEmptyDomains(t *testing.T) {
+	s := makeTestServer("", "/", []string{"example.com"})
+	body, _ := json.Marshal(api.HttpCertReq{Domains: nil})
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	var rw http.ResponseWriter = w
+	s.handleCertReq(&rw, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("empty domains: got %d want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// A pack that is subscribed but not yet issued holds a zero-value CertT.
+// Serving it would make the client overwrite its good on-disk cert with
+// empty files, so the request must fail loudly instead.
+func TestHandleCertReqSubscribedButNotIssued(t *testing.T) {
+	s := makeTestServer("", "/", []string{"example.com"})
+
+	entry, err := s.certCache.get([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("cert cache get: %v", err)
+	}
+	entry.stateMu.Lock()
+	entry.subscribing = 1
+	entry.stateMu.Unlock()
+
+	body, _ := json.Marshal(api.HttpCertReq{Domains: []string{"example.com"}})
+	// Cancelled request ctx so the wait for the in-flight issuance returns
+	// at once instead of burning httpCertWaitTimeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body)).WithContext(ctx)
+	w := httptest.NewRecorder()
+	var rw http.ResponseWriter = w
+	s.handleCertReq(&rw, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("not yet issued: got status %d want %d", w.Code, http.StatusServiceUnavailable)
+	}
+
+	var resp api.HttpCertResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err == nil && (len(resp.FullChain) != 0 || len(resp.Key) != 0) {
+		t.Fatalf("empty cert must never be served: %s", w.Body.String())
+	}
+}
+
+// A cert we actually hold is served even once its renew deadline has passed:
+// getting the renewal done is the renewer's job, and a 503 here would leave
+// the client with nothing rather than with a cert it can keep using until the
+// replacement lands. Only genuinely absent material earns a 503.
+func TestHandleCertReqSubscribedPastRenewDeadline(t *testing.T) {
+	s := makeTestServer("", "/", []string{"example.com"})
+
+	entry, err := s.certCache.get([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("cert cache get: %v", err)
+	}
+	entry.stateMu.Lock()
+	entry.cert = CertT{
+		FullChain:   []byte("PEM-chain"),
+		Key:         []byte("PEM-key"),
+		ValidBefore: time.Now().Add(-time.Hour),
+	}
+	entry.subscribing = 1
+	entry.stateMu.Unlock()
+
+	body, _ := json.Marshal(api.HttpCertReq{Domains: []string{"example.com"}})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body)).WithContext(ctx)
+	w := httptest.NewRecorder()
+	var rw http.ResponseWriter = w
+	s.handleCertReq(&rw, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("held cert past renew deadline: got status %d want %d", w.Code, http.StatusOK)
+	}
+	var resp api.HttpCertResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if string(resp.FullChain) != "PEM-chain" || string(resp.Key) != "PEM-key" {
+		t.Fatalf("served cert material: %q / %q", resp.FullChain, resp.Key)
+	}
+}
+
+// A sub-hour certLifeTime must yield a cert that is usable the instant it is
+// issued, whatever minute of the hour the issuance happens at. The
+// hour-truncated validity target used to land in the past for such configs, so
+// the freshly obtained cert was invalid on arrival: 503 on every request, and
+// one ACME obtain per request behind it.
+func TestHandleCertReqShortCertLifeTimeServes200(t *testing.T) {
+	s := newTestServer(t)
+	s.Config.HttpServer.APIPath = "/"
+	s.Config.ACME.AllowedDomains = []string{"example.com"}
+	s.Config.ACME.CertLifeTimeDuration = 30 * time.Second
+	s.Config.ACME.RenewTimeLeftDuration = 10 * time.Second
+
+	mock := acme.NewMockACME(5 * time.Minute)
+	obtainer := &fakeObtainer{fn: func(_ context.Context, domains []string) ([]byte, []byte, error) {
+		return mock.Obtain(context.Background(), domains, time.Time{})
+	}}
+	s.acme = obtainer
+
+	body, _ := json.Marshal(api.HttpCertReq{Domains: []string{"example.com"}})
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	var rw http.ResponseWriter = w
+	s.handleCertReq(&rw, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("30s certLifeTime: got status %d want %d", w.Code, http.StatusOK)
+	}
+
+	var resp api.HttpCertResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.FullChain) == 0 || len(resp.Key) == 0 {
+		t.Fatalf("200 with empty cert material: %s", w.Body.String())
+	}
+
+	entry, err := s.certCache.get([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("cert cache get: %v", err)
+	}
+	cert := entry.Cert()
+	if !cert.IsValid() {
+		t.Fatalf("cert is invalid the moment it was issued: ValidBefore %s, now %s", cert.ValidBefore, time.Now())
+	}
+
+	// A second request must be served from cache, not cost another issuance.
+	w2 := httptest.NewRecorder()
+	var rw2 http.ResponseWriter = w2
+	s.handleCertReq(&rw2, httptest.NewRequest("POST", "/", bytes.NewReader(body)))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second request: got status %d want %d", w2.Code, http.StatusOK)
+	}
+	if got := obtainer.calls.Load(); got != 1 {
+		t.Fatalf("obtain called %d times, want 1 (an invalid-on-arrival cert re-obtains per request)", got)
 	}
 }
 
@@ -128,7 +284,10 @@ func TestHandleCertReqValidDomainsCachedCert(t *testing.T) {
 	s := makeTestServer("", "/", []string{"example.com"})
 
 	// Pre-populate the cert cache with a valid cert.
-	entry := s.certCache.get([]string{"example.com"})
+	entry, err := s.certCache.get([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("cert cache get: %v", err)
+	}
 	entry.stateMu.Lock()
 	entry.cert = CertT{
 		FullChain:   []byte("PEM-chain"),
@@ -166,7 +325,7 @@ func TestHandleCertReqInvalidJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	var rw http.ResponseWriter = w
 	s.handleCertReq(&rw, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("invalid json: got %d want %d", w.Code, http.StatusInternalServerError)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid json: got %d want %d", w.Code, http.StatusBadRequest)
 	}
 }

--- a/pkg/server/sds.go
+++ b/pkg/server/sds.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"runtime/debug"
 	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -49,6 +50,39 @@ func sendStreamErr(ctx context.Context, errChan chan<- error, err error) {
 	select {
 	case errChan <- err:
 	case <-ctx.Done():
+	}
+}
+
+// recoverStream turns a panic in a per-stream goroutine into a stream
+// error. These goroutines are plain `go func()`s, so an unrecovered panic
+// on one malformed frame would take the whole server process down instead
+// of just the offending connection.
+func recoverStream(ctx context.Context, errChan chan<- error, what, peer string) {
+	if r := recover(); r != nil {
+		logging.Error("Panic while %s for %s: %v\n%s", what, peer, r, debug.Stack())
+		sendStreamErr(ctx, errChan, fmt.Errorf("panic while %s for %s: %v", what, peer, r))
+	}
+}
+
+// dispatchRequest hands req to a pack handler without ever blocking the
+// receive loop. The handler spends most of its life parked waiting for the
+// next renewal, so a blocking send here would wedge the receive loop and
+// with it every other cert pack sharing the stream. reqChan buffers a
+// single request; one that is still queued has been superseded by the
+// newer request, so it is dropped in its favor.
+func dispatchRequest(reqChan chan *discoveryv3.DiscoveryRequest, req *discoveryv3.DiscoveryRequest) {
+	for {
+		select {
+		case reqChan <- req:
+			return
+		default:
+		}
+
+		select {
+		case <-reqChan:
+		default:
+			// The handler drained it first, retry the send.
+		}
 	}
 }
 
@@ -97,6 +131,7 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 
 	go func() {
 		// goroutine for receiving
+		defer recoverStream(ctx, errChan, "receiving requests", peer)
 		for {
 			select {
 			case <-ctx.Done():
@@ -136,13 +171,11 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 
 			packRequests := map[string][]string{}
 			for _, name := range req.ResourceNames {
-				// this is an ack
+				// The pack is already served on this stream: this is an
+				// ack, a nack or a re-subscription. handleCert tells them
+				// apart, all we do here is hand the frame over.
 				if reqChan, ok := dispatch[name]; ok {
-					select {
-					case reqChan <- req:
-					case <-ctx.Done():
-						return
-					}
+					dispatchRequest(reqChan, req)
 					continue
 				}
 
@@ -176,9 +209,13 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 			for name, domains := range packRequests {
 				logging.Info("Handling pack %s with domains %v in response to %s", name, domains, peer)
 
-				entry := sds.cdxsrv.certCache.get(domains)
+				entry, err := sds.cdxsrv.certCache.get(domains)
+				if err != nil {
+					sendStreamErr(ctx, errChan, fmt.Errorf("cert pack %s: %w", name, err))
+					return
+				}
 
-				reqChan := make(chan *discoveryv3.DiscoveryRequest)
+				reqChan := make(chan *discoveryv3.DiscoveryRequest, 1)
 				dispatch[name] = reqChan
 				go sds.handleCert(ctx, name, entry, reqChan, resp, errChan, peer)
 			}
@@ -203,21 +240,65 @@ func (sds *MySDS) StreamSecrets(server secretv3.SecretDiscoveryService_StreamSec
 // so StreamSecrets returns from its outer select and gRPC closes the
 // connection — the previous "log and return from this goroutine"
 // behavior left the stream alive serving a stale or absent cert pack.
+//
+// Renewals and client frames are awaited in the same select: a client that
+// acks late (or never) must not delay the next cert, and a pack parked on a
+// renewal must not stall the stream's receive loop.
 func (sds *MySDS) handleCert(ctx context.Context, name string, entry *certEntry,
 	req chan *discoveryv3.DiscoveryRequest, resp chan *discoveryv3.DiscoveryResponse,
 	errChan chan<- error, peer string) {
+
+	defer recoverStream(ctx, errChan, fmt.Sprintf("serving cert pack %s", name), peer)
+
+	// Sub-context so the update watcher started below always winds down with
+	// this handler, including on an early error return. The deferred recover
+	// above captured the parent ctx, so it can still report a panic.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	sds.cdxsrv.subscribe(entry)
 	defer sds.cdxsrv.release(entry)
 
 	cert, seen := entry.Snapshot()
-	if !cert.IsValid() {
-		seen = entry.WaitForUpdate(ctx, seen)
-		if ctx.Err() != nil {
+
+	// Turn WaitForUpdate into a channel so renewals can be selected on
+	// alongside inbound frames. Buffered by one: a renewal that lands while
+	// the handler is busy is picked up on the next wait, because
+	// WaitForUpdate returns immediately once the version has moved past
+	// the last one this goroutine observed.
+	updates := make(chan struct{}, 1)
+	go func() {
+		for {
+			seen = entry.WaitForUpdate(ctx, seen)
+			if ctx.Err() != nil {
+				return
+			}
+			select {
+			case updates <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	for !cert.IsValid() {
+		select {
+		case <-updates:
+		case <-req:
+			// Nothing to offer yet, keep the frame from wedging the stream.
+			continue
+		case <-ctx.Done():
 			return
 		}
-		cert, seen = entry.Snapshot()
+		cert, _ = entry.Snapshot()
 	}
+
+	// reoffered bounds re-offers to one per cert version: on a stream
+	// carrying several packs the client acks with a single version that can
+	// match only one of them, so an unconditional re-offer would ping-pong
+	// between the packs forever. It is cleared whenever a renewal gives the
+	// pack something new to say.
+	reoffered := false
 
 	for {
 		secret, err := anypb.New(&tlsv3.Secret{
@@ -257,42 +338,72 @@ func (sds *MySDS) handleCert(ctx context.Context, name string, entry *certEntry,
 
 		logging.Info("Offered cert %v version %s to %s", entry.domains, version, peer)
 
-		select {
-		case ack := <-req:
-			if ack.VersionInfo == version {
-				logging.Info("Cert pack %s version %s deployed at %s", name, version, peer)
-			} else {
-				err := ack.ErrorDetail
-				logging.Warn("Cert version %s rejected by %s at %s: %d(%s)",
-					version, name, peer,
-					err.Code, err.Message)
+	awaitOffer:
+		for {
+			select {
+			case r := <-req:
+				switch {
+				case r.GetErrorDetail() != nil:
+					// NACK. Nothing better to send until the next renewal.
+					detail := r.GetErrorDetail()
+					logging.Warn("Cert pack %s version %s rejected by %s: %d(%s)",
+						name, version, peer, detail.GetCode(), detail.GetMessage())
+				case r.VersionInfo == version:
+					logging.Info("Cert pack %s version %s deployed at %s", name, version, peer)
+				case !reoffered:
+					// A frame naming this pack with some other version and
+					// no error detail: a re-subscription, or an ack for an
+					// offer this pack has already moved past. Re-offer the
+					// current cert once so a genuine re-subscription is
+					// served.
+					reoffered = true
+					logging.Info("Re-offering cert pack %s to %s, client reported version %q", name, peer, r.VersionInfo)
+					break awaitOffer
+				default:
+					logging.Debug("Cert pack %s: version %q from %s is stale, current is %s", name, r.VersionInfo, peer, version)
+				}
+			case <-updates:
+				cert, _ = entry.Snapshot()
+				reoffered = false
+				break awaitOffer
+			case <-ctx.Done():
+				logging.Debug("Message sender stopped due to ctx done: %s", ctx.Err())
+				return
 			}
-		case <-ctx.Done():
-			logging.Debug("Message sender stopped due to ctx done: %s", ctx.Err())
-			return
 		}
+	}
+}
 
-		seen = entry.WaitForUpdate(ctx, seen)
-		if ctx.Err() != nil {
-			logging.Debug("Message sender stopped due to ctx done: %s", ctx.Err())
-			return
-		}
-		cert, seen = entry.Snapshot()
+// logClientTLS audits the client certificate(s) presented by the peer of
+// ctx. Shared by the unary and stream interceptors: StreamSecrets is a
+// streaming RPC, so a unary-only interceptor never sees the SDS clients
+// this log exists for.
+func logClientTLS(ctx context.Context) {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p == nil {
+		return
+	}
+	mtls, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return
+	}
+	addr := peerAddr(ctx)
+	if len(mtls.State.PeerCertificates) > 1 {
+		logging.Error("Client %s providing multiple client certificate.", addr)
+	}
+	for _, item := range mtls.State.PeerCertificates {
+		logging.Info("Client `%s` from %s.", item.Subject.CommonName, addr)
 	}
 }
 
 func clientTLSLog(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-	if p, ok := peer.FromContext(ctx); ok {
-		if mtls, ok := p.AuthInfo.(credentials.TLSInfo); ok {
-			if len(mtls.State.PeerCertificates) > 1 {
-				logging.Error("Client %s providing multiple client certificate.", p.Addr.String())
-			}
-			for _, item := range mtls.State.PeerCertificates {
-				logging.Info("Client `%s` from %s.", item.Subject.CommonName, p.Addr.String())
-			}
-		}
-	}
+	logClientTLS(ctx)
 	return handler(ctx, req)
+}
+
+func clientTLSLogStream(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	logClientTLS(ss.Context())
+	return handler(srv, ss)
 }
 
 // SDSSrv runs the gRPC SDS endpoint until Stop is called. A goroutine
@@ -310,6 +421,7 @@ func (s *CertDXServer) SDSSrv() error {
 	grpcServer := grpc.NewServer(
 		grpc.Creds(credentials.NewTLS(mtlsConfig)),
 		grpc.UnaryInterceptor(clientTLSLog),
+		grpc.StreamInterceptor(clientTLSLogStream),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             time.Second,
 			PermitWithoutStream: true,

--- a/pkg/server/sds_test.go
+++ b/pkg/server/sds_test.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+// makeTestSDS builds an SDS server whose cert cache already holds a valid
+// cert for domains, so the per-entry renewer never reaches ACME.
+func makeTestSDS(t *testing.T, domains []string) (*MySDS, *certEntry) {
+	t.Helper()
+	s := makeTestServer("", "/", domains)
+	entry, err := s.certCache.get(domains)
+	if err != nil {
+		t.Fatalf("cert cache get: %v", err)
+	}
+	entry.stateMu.Lock()
+	entry.cert = CertT{
+		FullChain:   []byte("PEM-chain"),
+		Key:         []byte("PEM-key"),
+		ValidBefore: time.Now().Add(time.Hour),
+		RenewAt:     time.Now(),
+	}
+	entry.stateMu.Unlock()
+	return &MySDS{cdxsrv: s}, entry
+}
+
+func recvResp(t *testing.T, resp chan *discoveryv3.DiscoveryResponse) *discoveryv3.DiscoveryResponse {
+	t.Helper()
+	select {
+	case r := <-resp:
+		return r
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for an SDS response")
+		return nil
+	}
+}
+
+func expectNoResp(t *testing.T, resp chan *discoveryv3.DiscoveryResponse, errChan chan error) {
+	t.Helper()
+	select {
+	case r := <-resp:
+		t.Fatalf("unexpected extra SDS response: version %q", r.VersionInfo)
+	case err := <-errChan:
+		t.Fatalf("unexpected stream error: %s", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// A request whose version doesn't match the offer carries no ErrorDetail
+// unless it is a NACK. Reading Code/Message unconditionally used to panic
+// in a plain goroutine and take the whole process with it.
+func TestHandleCertVersionMismatchWithoutErrorDetail(t *testing.T) {
+	sds, entry := makeTestSDS(t, []string{"example.com"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := make(chan *discoveryv3.DiscoveryRequest, 1)
+	resp := make(chan *discoveryv3.DiscoveryResponse, 4)
+	errChan := make(chan error, 1)
+
+	go sds.handleCert(ctx, "pack", entry, req, resp, errChan, "test-peer")
+
+	offer := recvResp(t, resp)
+	if len(offer.Resources) != 1 {
+		t.Fatalf("first offer should carry one resource, got %d", len(offer.Resources))
+	}
+
+	// Stale ack / re-subscription: no error detail, mismatching version.
+	req <- &discoveryv3.DiscoveryRequest{VersionInfo: "not-the-offered-version"}
+
+	reoffer := recvResp(t, resp)
+	if reoffer.VersionInfo != offer.VersionInfo {
+		t.Fatalf("re-offer version: got %q want %q", reoffer.VersionInfo, offer.VersionInfo)
+	}
+
+	// Only one re-offer per version, otherwise two packs on one stream
+	// ping-pong forever.
+	req <- &discoveryv3.DiscoveryRequest{VersionInfo: "not-the-offered-version"}
+	expectNoResp(t, resp, errChan)
+}
+
+// A NACK must be logged, not answered with an immediate re-send of the
+// very cert that was just rejected.
+func TestHandleCertNackDoesNotResend(t *testing.T) {
+	sds, entry := makeTestSDS(t, []string{"example.com"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := make(chan *discoveryv3.DiscoveryRequest, 1)
+	resp := make(chan *discoveryv3.DiscoveryResponse, 4)
+	errChan := make(chan error, 1)
+
+	go sds.handleCert(ctx, "pack", entry, req, resp, errChan, "test-peer")
+
+	offer := recvResp(t, resp)
+	req <- &discoveryv3.DiscoveryRequest{
+		VersionInfo: offer.VersionInfo,
+		ErrorDetail: &rpcstatus.Status{Code: 13, Message: "bad cert"},
+	}
+	expectNoResp(t, resp, errChan)
+}
+
+// An ack is not required before the next renewal is offered: a client that
+// never acks must not park the pack forever.
+func TestHandleCertOffersRenewalWithoutAck(t *testing.T) {
+	sds, entry := makeTestSDS(t, []string{"example.com"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := make(chan *discoveryv3.DiscoveryRequest, 1)
+	resp := make(chan *discoveryv3.DiscoveryResponse, 4)
+	errChan := make(chan error, 1)
+
+	go sds.handleCert(ctx, "pack", entry, req, resp, errChan, "test-peer")
+
+	offer := recvResp(t, resp)
+
+	// Renew without any ack for the first offer.
+	entry.stateMu.Lock()
+	entry.cert = CertT{
+		FullChain:   []byte("PEM-chain-2"),
+		Key:         []byte("PEM-key-2"),
+		ValidBefore: time.Now().Add(2 * time.Hour),
+		RenewAt:     time.Now().Add(time.Minute),
+	}
+	entry.version++
+	close(entry.updated)
+	entry.updated = make(chan struct{})
+	entry.stateMu.Unlock()
+
+	next := recvResp(t, resp)
+	if next.VersionInfo == offer.VersionInfo {
+		t.Fatalf("renewal was not offered: still at version %q", next.VersionInfo)
+	}
+}
+
+// The receive loop must never block on a pack handler that is parked
+// waiting for a renewal, and the newest request wins.
+func TestDispatchRequestNeverBlocks(t *testing.T) {
+	reqChan := make(chan *discoveryv3.DiscoveryRequest, 1)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 5; i++ {
+			dispatchRequest(reqChan, &discoveryv3.DiscoveryRequest{VersionInfo: string(rune('a' + i))})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatchRequest blocked with no handler reading")
+	}
+
+	got := <-reqChan
+	if got.VersionInfo != "e" {
+		t.Fatalf("stale request served: got %q want %q", got.VersionInfo, "e")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"sync"
@@ -10,6 +12,26 @@ import (
 	"pkg.para.party/certdx/pkg/acme"
 	"pkg.para.party/certdx/pkg/config"
 	"pkg.para.party/certdx/pkg/logging"
+)
+
+const (
+	// renewRetryMinInterval / renewRetryMaxInterval bound the exponential
+	// backoff a renewer uses while the entry holds no cert — a failed ACME
+	// obtain must not park the entry for RenewTimeLeft/4 (6h by default).
+	renewRetryMinInterval = 30 * time.Second
+	renewRetryMaxInterval = 5 * time.Minute
+
+	// renewCheckMinInterval floors the healthy steady-state re-check
+	// interval, so a zero or negative RenewTimeLeft that slipped through
+	// config validation can't turn the renewer into a busy loop.
+	renewCheckMinInterval = 5 * time.Second
+
+	// shutdownDrainTimeout caps how long Stop / Wait block joining the
+	// cache-file writer before giving up, so a wedged goroutine can't hang
+	// process exit forever. It is a backstop only: the writer exits within
+	// microseconds of rootCtx firing, and renewers are deliberately not
+	// joined (see subscribe).
+	shutdownDrainTimeout = 30 * time.Second
 )
 
 type CertT struct {
@@ -26,6 +48,12 @@ type CertDXServer struct {
 	certCache certCache
 	certStore CertStore
 
+	// renewRetryMin / renewRetryMax bound the renewer's retry backoff.
+	// Seeded from the package defaults by MakeCertDXServer; per-server so
+	// tests can shrink them without racing other servers' renewers.
+	renewRetryMin time.Duration
+	renewRetryMax time.Duration
+
 	// rootCtx is the lifecycle parent for every server subgoroutine
 	// (HttpSrv, SDSSrv, the cache-file writer, every per-entry renewer).
 	// Stop cancels it exactly once via stopOnce. There is no separate
@@ -33,6 +61,14 @@ type CertDXServer struct {
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
 	stopOnce   sync.Once
+	// wg tracks only the subgoroutines Stop must join before the process may
+	// exit — currently just the cache-file writer, whose drain would
+	// otherwise race process exit and truncate cache.json. Renewers are NOT
+	// tracked: they park inside lego's non-context-aware Obtain, so joining
+	// them would burn shutdownDrainTimeout on every shutdown that catches an
+	// issuance in flight and race the caller's own shutdown deadline. They
+	// are best-effort on shutdown and select on rootCtx between attempts.
+	wg sync.WaitGroup
 }
 
 func MakeCertDXServer() (*CertDXServer, error) {
@@ -42,10 +78,12 @@ func MakeCertDXServer() (*CertDXServer, error) {
 	}
 	rootCtx, rootCancel := context.WithCancel(context.Background())
 	ret := &CertDXServer{
-		certCache:  makeCertCache(),
-		certStore:  store,
-		rootCtx:    rootCtx,
-		rootCancel: rootCancel,
+		certCache:     makeCertCache(),
+		certStore:     store,
+		rootCtx:       rootCtx,
+		rootCancel:    rootCancel,
+		renewRetryMin: renewRetryMinInterval,
+		renewRetryMax: renewRetryMaxInterval,
 	}
 	ret.Config.SetDefault()
 
@@ -64,11 +102,25 @@ func (s *CertDXServer) Init() error {
 		return fmt.Errorf("initialize ACME: %w", err)
 	}
 
+	s.certCache.setMaxEntries(s.Config.ACME.MaxCacheEntries)
+
 	if err = s.loadCertStore(); err != nil {
 		// It's okay that previous saved cert can not be loaded, just log and continue to run
 		logging.Warn("Load cache file failed: %s", err)
 	}
-	go s.certStore.listenUpdate(s.rootCtx)
+
+	// The cache-file writer is the one goroutine Stop joins. Adding to wg
+	// after Stop has already drained would race wg.Wait, so an Init that
+	// somehow runs against a stopped server just skips it — listenUpdate
+	// would return on the cancelled rootCtx immediately anyway.
+	if s.rootCtx.Err() != nil {
+		return nil
+	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.certStore.listenUpdate(s.rootCtx)
+	}()
 
 	return nil
 }
@@ -85,7 +137,11 @@ func (s *CertDXServer) loadCertStore() error {
 
 	s.certCache.mutex.Lock()
 	for _, cache := range s.certStore.entries {
-		entry := s.certCache.getNoLock(cache.Domains)
+		entry, err := s.certCache.getNoLock(cache.Domains)
+		if err != nil {
+			logging.Warn("Skipping cached cert for domains %v: %s", cache.Domains, err)
+			continue
+		}
 		entry.stateMu.Lock()
 		entry.cert = cache.Cert
 		entry.stateMu.Unlock()
@@ -124,7 +180,7 @@ func (s *CertDXServer) renew(ctx context.Context, c *certEntry, retry bool) (boo
 		return false, nil
 	}
 
-	newValidBefore := time.Now().Truncate(1 * time.Hour).Add(s.Config.ACME.CertLifeTimeDuration)
+	newValidBefore := targetValidBefore(time.Now(), s.Config.ACME.CertLifeTimeDuration)
 
 	var fullchain, key []byte
 	var err error
@@ -137,10 +193,42 @@ func (s *CertDXServer) renew(ctx context.Context, c *certEntry, retry bool) (boo
 		return false, err
 	}
 
+	// The issuer, not our config, decides how long the cert is actually
+	// valid. Clamp ValidBefore against the leaf's real NotAfter (minus the
+	// renew margin) so a too-generous certLifeTime can't keep an expired
+	// cert in service. A leaf we can't parse is only logged: the cert is
+	// still usable, we just fall back to the configured lifetime.
+	validBefore := newValidBefore
+	if notAfter, perr := leafNotAfter(fullchain); perr != nil {
+		logging.Warn("Could not read NotAfter of issued cert %v: %s", c.domains, perr)
+	} else {
+		var outcome clampOutcome
+		validBefore, outcome = clampValidBefore(time.Now(), newValidBefore, notAfter, s.Config.ACME.RenewTimeLeftDuration)
+		switch outcome {
+		case clampNone:
+		case clampApplied:
+			// Losing up to renewTimeLeft-ish here is the normal consequence of
+			// the CA backdating notBefore and of our own hour-truncation, and
+			// happens on every renewal of a config sitting at the provider's
+			// maximum lifetime. Only a materially shorter cert is worth a Warn.
+			if newValidBefore.Sub(validBefore) > clampWarnThreshold(s.Config.ACME.CertLifeTimeDuration) {
+				logging.Warn("Issued cert %v expires at %s, capping validBefore %s -> %s (check certLifeTime)",
+					c.domains, notAfter, newValidBefore, validBefore)
+			} else {
+				logging.Debug("Issued cert %v expires at %s, capping validBefore %s -> %s",
+					c.domains, notAfter, newValidBefore, validBefore)
+			}
+		case clampFloored:
+			logging.Warn("Issued cert %v expires at %s, sooner than renewTimeLeft (%s) from now; "+
+				"serving it until %s instead of treating it as already expired (check renewTimeLeft)",
+				c.domains, notAfter, s.Config.ACME.RenewTimeLeftDuration, validBefore)
+		}
+	}
+
 	newCert := CertT{
 		FullChain:   fullchain,
 		Key:         key,
-		ValidBefore: newValidBefore,
+		ValidBefore: validBefore,
 		RenewAt:     time.Now(),
 	}
 
@@ -155,29 +243,147 @@ func (s *CertDXServer) renew(ctx context.Context, c *certEntry, retry bool) (boo
 	c.updated = make(chan struct{})
 	c.stateMu.Unlock()
 
-	// Hand off the persisted cert to the cache-file writer. If the writer
-	// has already exited (e.g. Stop fired and drained the buffer), we
-	// honor ctx instead of blocking forever on a buffered send that no
-	// one will receive.
-	select {
-	case s.certStore.update <- &certStoreEntry{
+	// Hand off the persisted cert to the cache-file writer. The handoff is
+	// gated on the writer's lifecycle (rootCtx), never on the caller's ctx:
+	// a cancelled request/subscription must not lose a real ACME issuance
+	// that has already been broadcast. Try the buffered channel first, and
+	// only then block until the writer takes it or the writer is gone.
+	storeEntry := &certStoreEntry{
 		Domains: c.domains,
 		Cert:    newCert,
-	}:
-	case <-ctx.Done():
-		return true, nil
+	}
+	select {
+	case s.certStore.update <- storeEntry:
+	default:
+		select {
+		case s.certStore.update <- storeEntry:
+		case <-s.rootCtx.Done():
+			logging.Warn("Cert store writer stopped, new cert %v was not persisted", c.domains)
+		}
 	}
 
 	logging.Info("Obtained new cert: %v", c.domains)
 	return true, nil
 }
 
+// targetValidBefore is the ValidBefore a renewal aims for: certLifeTime past
+// the top of the current hour.
+//
+// The hour truncation keeps renewals aligned on hour boundaries, but it also
+// subtracts up to 59m59s of lifetime, so for a certLifeTime shorter than the
+// elapsed part of the current hour the truncated target lands in the *past* —
+// the freshly issued cert would be born invalid, the SDS handler would never
+// offer it, the HTTP handler would answer 503 forever and the renewer would
+// re-obtain on every check. Whenever truncation would do that, aim from now
+// instead. certLifeTime is validated positive by config, so the result is
+// always strictly after now.
+func targetValidBefore(now time.Time, certLifeTime time.Duration) time.Time {
+	target := now.Truncate(1 * time.Hour).Add(certLifeTime)
+	if !target.After(now) {
+		return now.Add(certLifeTime)
+	}
+	return target
+}
+
+// clampOutcome reports how clampValidBefore reconciled the configured
+// ValidBefore with the leaf's real NotAfter.
+type clampOutcome int
+
+const (
+	// clampNone: the cert outlives the configured target, nothing to do.
+	clampNone clampOutcome = iota
+	// clampApplied: ValidBefore was pulled back to NotAfter - renewTimeLeft.
+	clampApplied
+	// clampFloored: NotAfter - renewTimeLeft is already in the past, so the
+	// margin was dropped rather than declaring the new cert invalid at birth.
+	clampFloored
+)
+
+// clampValidBefore returns the ValidBefore to record for a freshly issued
+// cert whose leaf really expires at notAfter.
+//
+// The configured target is shortened to notAfter - renewTimeLeft so a
+// too-generous certLifeTime can't keep an expired cert in service. That
+// subtraction has a floor: if the CA issues a cert whose whole lifetime is
+// shorter than renewTimeLeft, the clamped value lands in the past and the
+// cert would be invalid the moment it was obtained — 503 on every request
+// plus one ACME obtain per request. In that case keep min(configured,
+// notAfter) instead, which is still a real expiry and always after now
+// (configured is, by targetValidBefore). Only a leaf that is already expired
+// on arrival falls back to the configured target outright; nothing about
+// such a cert is trustworthy and refusing to serve it helps no one.
+func clampValidBefore(now, configured, notAfter time.Time, renewTimeLeft time.Duration) (time.Time, clampOutcome) {
+	renewBy := notAfter.Add(-renewTimeLeft)
+	if !renewBy.Before(configured) {
+		return configured, clampNone
+	}
+	if renewBy.After(now) {
+		return renewBy, clampApplied
+	}
+
+	clamped := configured
+	if notAfter.Before(clamped) {
+		clamped = notAfter
+	}
+	if !clamped.After(now) {
+		return configured, clampFloored
+	}
+	return clamped, clampFloored
+}
+
+// clampWarnThreshold is how much shorter than the configured target the
+// clamped ValidBefore has to be before it is worth a Warn rather than a
+// Debug line. The everyday clamp — a config at the provider's maximum
+// lifetime, where the CA backdates notBefore by about an hour and our own
+// hour-truncation gives up to another 59m — must not warn on every single
+// renewal, but a clamp that eats a real fraction of the configured lifetime
+// means certLifeTime is set higher than the provider will ever issue.
+func clampWarnThreshold(certLifeTime time.Duration) time.Duration {
+	threshold := 2 * time.Hour
+	if fraction := certLifeTime / 10; fraction > threshold {
+		threshold = fraction
+	}
+	return threshold
+}
+
+// leafNotAfter parses the leaf (first) certificate of a PEM fullchain and
+// returns its real expiry.
+func leafNotAfter(fullchain []byte) (time.Time, error) {
+	rest := fullchain
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return time.Time{}, fmt.Errorf("no certificate block in fullchain")
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parse leaf certificate: %w", err)
+		}
+		return cert.NotAfter, nil
+	}
+}
+
 func (s *CertDXServer) subscribeCertCacheEntry(ctx context.Context, c *certEntry) {
 	logging.Info("Start subscribing cert: %v", c.domains)
 	defer logging.Info("Stopped subscribing cert: %v", c.domains)
 
+	// Guard against a server that was built without MakeCertDXServer: a
+	// zero backoff would turn the retry path into a busy loop.
+	retryMin, retryMax := s.renewRetryMin, s.renewRetryMax
+	if retryMin <= 0 {
+		retryMin = renewRetryMinInterval
+	}
+	if retryMax < retryMin {
+		retryMax = max(retryMin, renewRetryMaxInterval)
+	}
+
+	backoff := retryMin
 	for {
-		_, err := s.renew(ctx, c, true)
+		obtained, err := s.renew(ctx, c, true)
 		if err != nil {
 			if ctx.Err() != nil {
 				return
@@ -185,7 +391,23 @@ func (s *CertDXServer) subscribeCertCacheEntry(ctx context.Context, c *certEntry
 			logging.Error("Failed to renew cert %s: %s", c.domains, err)
 		}
 
-		t := time.NewTimer(s.Config.ACME.RenewTimeLeftDuration / 4)
+		// Only the healthy steady state earns the long interval: renew
+		// succeeded and the entry now holds a cert (one we just minted, or
+		// a still-valid cached one). A failed obtain leaves the entry
+		// without a usable cert, so re-check on a short backoff instead of
+		// parking it for RenewTimeLeft/4.
+		var wait time.Duration
+		cert := c.Cert()
+		if err == nil && (obtained || cert.IsValid()) {
+			wait = s.renewCheckInterval()
+			backoff = retryMin
+		} else {
+			wait = backoff
+			backoff = min(backoff*2, retryMax)
+			logging.Warn("No usable cert for %v, re-checking in %s", c.domains, wait)
+		}
+
+		t := time.NewTimer(wait)
 		select {
 		case <-t.C:
 			// Do next check
@@ -196,10 +418,28 @@ func (s *CertDXServer) subscribeCertCacheEntry(ctx context.Context, c *certEntry
 	}
 }
 
+// renewCheckInterval is the healthy-state re-check cadence: a quarter of
+// RenewTimeLeft, floored so a zero or negative configured value can't spin
+// the renewer.
+func (s *CertDXServer) renewCheckInterval() time.Duration {
+	interval := s.Config.ACME.RenewTimeLeftDuration / 4
+	if interval < renewCheckMinInterval {
+		return renewCheckMinInterval
+	}
+	return interval
+}
+
 // Subscribe registers a consumer for the entry's renewal stream. The first
 // subscriber kicks off a per-entry renewal goroutine whose context is
-// derived from rootCtx (so server Stop drains it cleanly); further
-// subscribers just bump the refcount.
+// derived from rootCtx (so server Stop signals it); further subscribers just
+// bump the refcount.
+//
+// The renewer is deliberately not registered in s.wg: it can be parked
+// inside lego's Obtain, which is not context-aware, so Stop could not
+// unblock it and would simply burn shutdownDrainTimeout before giving up —
+// long enough to blow past the caller's own shutdown deadline. Renewers are
+// best-effort on shutdown; they check rootCtx between attempts, and a cert
+// obtained during shutdown is handed to the store writer, which *is* joined.
 func (s *CertDXServer) subscribe(c *certEntry) {
 	var (
 		ctx    context.Context
@@ -249,17 +489,41 @@ func (s *CertDXServer) isSubscribing(c *certEntry) bool {
 	return c.subscribing != 0
 }
 
-// Stop signals every server goroutine to wind down. It is safe to call
-// concurrently and from any number of callers; only the first call cancels
-// the root context.
+// Stop signals every server goroutine to wind down and blocks until they
+// have. It is safe to call concurrently and from any number of callers; only
+// the first call cancels the root context. The wait is bounded by
+// shutdownDrainTimeout so a wedged goroutine can't hang shutdown.
 func (s *CertDXServer) Stop() {
 	s.stopOnce.Do(s.rootCancel)
+	s.drain()
 }
 
 // Wait blocks until Stop is called (by signal handler, by a failing
 // subserver, or by any other caller). main uses it as the single
 // blocking point so a subserver crash doesn't leave the process alive
-// with no listener.
+// with no listener. It also joins the subgoroutines, so returning from
+// Wait means the cache file has been written out.
 func (s *CertDXServer) Wait() {
 	<-s.rootCtx.Done()
+	s.drain()
+}
+
+// drain joins the tracked subgoroutines — the cache-file writer, whose
+// shutdown drain would otherwise race process exit and leave cache.json
+// truncated mid-write. That writer returns as soon as rootCtx fires, so
+// drain is effectively instant; the timeout is only a backstop.
+func (s *CertDXServer) drain() {
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+
+	t := time.NewTimer(shutdownDrainTimeout)
+	defer t.Stop()
+	select {
+	case <-done:
+	case <-t.C:
+		logging.Warn("Timed out after %s waiting for server goroutines to stop", shutdownDrainTimeout)
+	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,470 @@
+package server
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"pkg.para.party/certdx/pkg/acme"
+	"pkg.para.party/certdx/pkg/domain"
+)
+
+// fakeObtainer is an acme.Obtainer stand-in whose behavior each test picks.
+type fakeObtainer struct {
+	calls atomic.Int64
+	fn    func(ctx context.Context, domains []string) ([]byte, []byte, error)
+}
+
+func (f *fakeObtainer) Obtain(ctx context.Context, domains []string, _ time.Time) ([]byte, []byte, error) {
+	f.calls.Add(1)
+	return f.fn(ctx, domains)
+}
+
+func (f *fakeObtainer) RetryObtain(ctx context.Context, domains []string, deadline time.Time) ([]byte, []byte, error) {
+	return f.Obtain(ctx, domains, deadline)
+}
+
+// newTestServer builds a server whose cert store writes into a temp dir, so
+// tests never touch the real cache.json.
+func newTestServer(t *testing.T) *CertDXServer {
+	t.Helper()
+	s, err := MakeCertDXServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.certStore = CertStore{
+		path:    filepath.Join(t.TempDir(), "cache.json"),
+		entries: make(map[domain.Key]*certStoreEntry),
+		update:  make(chan *certStoreEntry, 10),
+	}
+	return s
+}
+
+func TestLeafNotAfterReadsIssuedCert(t *testing.T) {
+	mock := acme.NewMockACME(90 * time.Minute)
+	fullchain, _, err := mock.Obtain(context.Background(), []string{"example.com"}, time.Time{})
+	if err != nil {
+		t.Fatalf("mock obtain: %v", err)
+	}
+
+	notAfter, err := leafNotAfter(fullchain)
+	if err != nil {
+		t.Fatalf("leafNotAfter: %v", err)
+	}
+	if d := time.Until(notAfter); d < 80*time.Minute || d > 100*time.Minute {
+		t.Fatalf("NotAfter in %s, want ~90m", d)
+	}
+}
+
+func TestLeafNotAfterRejectsGarbage(t *testing.T) {
+	if _, err := leafNotAfter([]byte("not pem at all")); err == nil {
+		t.Fatal("expected error for non-PEM input")
+	}
+	junk := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("nope")})
+	if _, err := leafNotAfter(junk); err == nil {
+		t.Fatal("expected error for unparsable certificate")
+	}
+}
+
+// A certLifeTime longer than what the CA actually issues must not keep an
+// expired cert in service: ValidBefore is clamped to the leaf's real NotAfter
+// minus the renew margin.
+func TestRenewClampsValidBeforeToRealNotAfter(t *testing.T) {
+	s := newTestServer(t)
+	s.Config.ACME.CertLifeTimeDuration = 168 * time.Hour
+	s.Config.ACME.RenewTimeLeftDuration = time.Hour
+	s.acme = acme.NewMockACME(2 * time.Hour)
+
+	entry := newCertEntry([]string{"example.com"})
+	obtained, err := s.renew(context.Background(), entry, false)
+	if err != nil || !obtained {
+		t.Fatalf("renew: obtained=%v err=%v", obtained, err)
+	}
+
+	cert := entry.Cert()
+	notAfter, err := leafNotAfter(cert.FullChain)
+	if err != nil {
+		t.Fatalf("leafNotAfter: %v", err)
+	}
+	want := notAfter.Add(-s.Config.ACME.RenewTimeLeftDuration)
+	if !cert.ValidBefore.Equal(want) {
+		t.Fatalf("ValidBefore = %s, want %s (leaf NotAfter %s)", cert.ValidBefore, want, notAfter)
+	}
+	if cert.ValidBefore.After(notAfter) {
+		t.Fatal("ValidBefore outlives the certificate itself")
+	}
+}
+
+// A cert that is issued for longer than certLifeTime keeps the configured
+// (shorter) ValidBefore — the clamp only ever shortens.
+func TestRenewKeepsConfiguredValidBeforeWhenShorter(t *testing.T) {
+	s := newTestServer(t)
+	s.Config.ACME.CertLifeTimeDuration = time.Hour
+	s.Config.ACME.RenewTimeLeftDuration = time.Minute
+	s.acme = acme.NewMockACME(240 * time.Hour)
+
+	entry := newCertEntry([]string{"example.com"})
+	if _, err := s.renew(context.Background(), entry, false); err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+
+	want := time.Now().Truncate(time.Hour).Add(time.Hour)
+	if !entry.Cert().ValidBefore.Equal(want) {
+		t.Fatalf("ValidBefore = %s, want configured %s", entry.Cert().ValidBefore, want)
+	}
+}
+
+// The hour-truncated validity target loses up to 59m59s of lifetime, which for
+// a sub-hour certLifeTime puts ValidBefore in the past: the cert is invalid the
+// moment it is minted, SDS never offers it, HTTP answers 503 forever and the
+// renewer re-obtains on every check. Whatever the wall clock and the configured
+// lifetime, the target must be strictly in the future.
+func TestTargetValidBeforeIsAlwaysInTheFuture(t *testing.T) {
+	base := time.Date(2026, 8, 15, 13, 0, 0, 0, time.UTC)
+	offsets := []time.Duration{
+		0, time.Second, 30 * time.Second, time.Minute, 29 * time.Minute,
+		30*time.Minute + 1, 59 * time.Minute, 59*time.Minute + 59*time.Second,
+	}
+	lifetimes := []time.Duration{
+		time.Second, 30 * time.Second, time.Minute, 30 * time.Minute,
+		time.Hour, 168 * time.Hour,
+	}
+
+	for _, off := range offsets {
+		now := base.Add(off)
+		for _, life := range lifetimes {
+			got := targetValidBefore(now, life)
+			if !got.After(now) {
+				t.Fatalf("now %s, certLifeTime %s: target %s is not after now", now, life, got)
+			}
+			// Never hand out more lifetime than configured either.
+			if got.After(now.Add(life)) {
+				t.Fatalf("now %s, certLifeTime %s: target %s overshoots now+certLifeTime", now, life, got)
+			}
+		}
+	}
+}
+
+// Hour alignment is still the rule whenever it produces a usable target.
+func TestTargetValidBeforeKeepsHourAlignment(t *testing.T) {
+	now := time.Date(2026, 8, 15, 13, 42, 17, 0, time.UTC)
+	got := targetValidBefore(now, 168*time.Hour)
+	want := now.Truncate(time.Hour).Add(168 * time.Hour)
+	if !got.Equal(want) {
+		t.Fatalf("target = %s, want hour-aligned %s", got, want)
+	}
+}
+
+func TestClampValidBefore(t *testing.T) {
+	now := time.Date(2026, 8, 15, 13, 42, 17, 0, time.UTC)
+	configured := now.Add(24 * time.Hour)
+
+	cases := []struct {
+		name        string
+		notAfter    time.Time
+		renewLeft   time.Duration
+		want        time.Time
+		wantOutcome clampOutcome
+	}{
+		{
+			name:        "cert outlives configured target",
+			notAfter:    now.Add(90 * 24 * time.Hour),
+			renewLeft:   time.Hour,
+			want:        configured,
+			wantOutcome: clampNone,
+		},
+		{
+			name:        "cert shorter than configured, margin still fits",
+			notAfter:    now.Add(6 * time.Hour),
+			renewLeft:   time.Hour,
+			want:        now.Add(5 * time.Hour),
+			wantOutcome: clampApplied,
+		},
+		{
+			// The clamped value would be in the past: keep the cert's real
+			// expiry instead of declaring it invalid at birth.
+			name:        "cert lifetime shorter than the renew margin",
+			notAfter:    now.Add(10 * time.Minute),
+			renewLeft:   time.Hour,
+			want:        now.Add(10 * time.Minute),
+			wantOutcome: clampFloored,
+		},
+		{
+			name:        "clamped value lands exactly on now",
+			notAfter:    now.Add(time.Hour),
+			renewLeft:   time.Hour,
+			want:        now.Add(time.Hour),
+			wantOutcome: clampFloored,
+		},
+		{
+			// Nothing sane to derive from a leaf that is already expired;
+			// keep the configured (future) target so the entry stays usable.
+			name:        "leaf already expired on arrival",
+			notAfter:    now.Add(-time.Minute),
+			renewLeft:   time.Hour,
+			want:        configured,
+			wantOutcome: clampFloored,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, outcome := clampValidBefore(now, configured, tc.notAfter, tc.renewLeft)
+			if !got.Equal(tc.want) {
+				t.Fatalf("validBefore = %s, want %s", got, tc.want)
+			}
+			if outcome != tc.wantOutcome {
+				t.Fatalf("outcome = %d, want %d", outcome, tc.wantOutcome)
+			}
+			if !got.After(now) {
+				t.Fatalf("validBefore %s is not after now %s", got, now)
+			}
+		})
+	}
+}
+
+// The everyday clamp (CA backdates notBefore ~1h, our own target loses up to
+// 59m to hour-truncation) must stay below the warn threshold; a clamp that
+// eats a real fraction of the configured lifetime must cross it.
+func TestClampWarnThreshold(t *testing.T) {
+	const life = 60 * 24 * time.Hour
+	if got := clampWarnThreshold(life); got <= 2*time.Hour {
+		t.Fatalf("threshold for %s = %s, want more than the ~2h everyday clamp", life, got)
+	}
+	if got := clampWarnThreshold(30 * time.Second); got < 2*time.Hour {
+		t.Fatalf("threshold for a sub-hour lifetime = %s, want at least 2h", got)
+	}
+}
+
+// A cert whose real lifetime is shorter than renewTimeLeft used to get a
+// ValidBefore in the past, so it was invalid the moment it was obtained:
+// permanent 503 plus one ACME obtain per request.
+func TestRenewCertShorterThanRenewMarginStaysValid(t *testing.T) {
+	s := newTestServer(t)
+	s.Config.ACME.CertLifeTimeDuration = 168 * time.Hour
+	s.Config.ACME.RenewTimeLeftDuration = 24 * time.Hour
+	s.acme = acme.NewMockACME(30 * time.Minute)
+
+	entry := newCertEntry([]string{"example.com"})
+	if _, err := s.renew(context.Background(), entry, false); err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+
+	cert := entry.Cert()
+	if !cert.IsValid() {
+		t.Fatalf("cert invalid on arrival: ValidBefore %s, now %s", cert.ValidBefore, time.Now())
+	}
+	notAfter, err := leafNotAfter(cert.FullChain)
+	if err != nil {
+		t.Fatalf("leafNotAfter: %v", err)
+	}
+	if cert.ValidBefore.After(notAfter) {
+		t.Fatalf("ValidBefore %s outlives the certificate itself (%s)", cert.ValidBefore, notAfter)
+	}
+}
+
+// A sub-hour certLifeTime issued at an arbitrary point in the hour must
+// produce an immediately valid cert, and the renewer must then treat the entry
+// as healthy instead of re-obtaining on every check.
+func TestRenewShortCertLifeTimeIsValidImmediately(t *testing.T) {
+	s := newTestServer(t)
+	s.Config.ACME.CertLifeTimeDuration = 30 * time.Second
+	s.Config.ACME.RenewTimeLeftDuration = 10 * time.Second
+
+	mock := acme.NewMockACME(5 * time.Minute)
+	fake := &fakeObtainer{fn: func(_ context.Context, domains []string) ([]byte, []byte, error) {
+		return mock.Obtain(context.Background(), domains, time.Time{})
+	}}
+	s.acme = fake
+
+	entry := newCertEntry([]string{"example.com"})
+	if _, err := s.renew(context.Background(), entry, false); err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+
+	cert := entry.Cert()
+	if !cert.IsValid() {
+		t.Fatalf("cert invalid on arrival: ValidBefore %s, now %s", cert.ValidBefore, time.Now())
+	}
+	if d := time.Until(cert.ValidBefore); d > 30*time.Second {
+		t.Fatalf("ValidBefore is %s out, longer than the configured 30s lifetime", d)
+	}
+
+	// The renewer's early return keys on the same IsValid check.
+	obtained, err := s.renew(context.Background(), entry, false)
+	if err != nil {
+		t.Fatalf("second renew: %v", err)
+	}
+	if obtained {
+		t.Fatal("renew re-obtained a cert it had just issued")
+	}
+	if got := fake.calls.Load(); got != 1 {
+		t.Fatalf("obtain called %d times, want 1", got)
+	}
+}
+
+// A cancelled caller ctx (subscription or HTTP request) must not cost us a
+// real issuance: the cert still reaches the cache-file writer.
+func TestRenewPersistsWhenCallerCtxCancelled(t *testing.T) {
+	s := newTestServer(t)
+	s.Config.ACME.CertLifeTimeDuration = 168 * time.Hour
+	s.Config.ACME.RenewTimeLeftDuration = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mock := acme.NewMockACME(48 * time.Hour)
+	s.acme = &fakeObtainer{fn: func(obtainCtx context.Context, domains []string) ([]byte, []byte, error) {
+		// The caller goes away while the ACME round-trip is in flight.
+		cancel()
+		return mock.Obtain(context.Background(), domains, time.Time{})
+	}}
+
+	entry := newCertEntry([]string{"example.com"})
+	obtained, err := s.renew(ctx, entry, false)
+	if err != nil || !obtained {
+		t.Fatalf("renew: obtained=%v err=%v", obtained, err)
+	}
+
+	select {
+	case fe := <-s.certStore.update:
+		if len(fe.Domains) != 1 || fe.Domains[0] != "example.com" {
+			t.Fatalf("persisted domains: %v", fe.Domains)
+		}
+	default:
+		t.Fatal("obtained cert was broadcast but never handed to the cert store")
+	}
+}
+
+func TestRenewCheckIntervalFloorsShortRenewTimeLeft(t *testing.T) {
+	s := newTestServer(t)
+
+	s.Config.ACME.RenewTimeLeftDuration = 24 * time.Hour
+	if got := s.renewCheckInterval(); got != 6*time.Hour {
+		t.Fatalf("interval = %s, want 6h", got)
+	}
+
+	for _, d := range []time.Duration{0, -time.Hour, time.Second} {
+		s.Config.ACME.RenewTimeLeftDuration = d
+		if got := s.renewCheckInterval(); got != renewCheckMinInterval {
+			t.Fatalf("RenewTimeLeft %s: interval = %s, want floor %s", d, got, renewCheckMinInterval)
+		}
+	}
+}
+
+// A failing obtain must be retried on the short backoff instead of parking the
+// entry for RenewTimeLeft/4 (6h with the default config).
+func TestRenewerRetriesQuicklyWhenNoValidCert(t *testing.T) {
+	s := newTestServer(t)
+	s.renewRetryMin, s.renewRetryMax = 10*time.Millisecond, 20*time.Millisecond
+	s.Config.ACME.CertLifeTimeDuration = 168 * time.Hour
+	s.Config.ACME.RenewTimeLeftDuration = 24 * time.Hour // healthy interval would be 6h
+
+	fake := &fakeObtainer{fn: func(context.Context, []string) ([]byte, []byte, error) {
+		return nil, nil, fmt.Errorf("acme is down")
+	}}
+	s.acme = fake
+
+	entry := newCertEntry([]string{"example.com"})
+	s.subscribe(entry)
+	defer s.release(entry)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fake.calls.Load() < 3 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := fake.calls.Load(); got < 3 {
+		t.Fatalf("obtain called %d times, want >= 3 (renewer parked on the long interval)", got)
+	}
+}
+
+// Once a cert is in hand the renewer falls back to the long steady-state
+// interval rather than hammering ACME on the retry backoff.
+func TestRenewerUsesLongIntervalWhenHealthy(t *testing.T) {
+	s := newTestServer(t)
+	s.renewRetryMin, s.renewRetryMax = 10*time.Millisecond, 20*time.Millisecond
+	s.Config.ACME.CertLifeTimeDuration = 168 * time.Hour
+	s.Config.ACME.RenewTimeLeftDuration = 24 * time.Hour
+
+	mock := acme.NewMockACME(240 * time.Hour)
+	fake := &fakeObtainer{fn: func(_ context.Context, domains []string) ([]byte, []byte, error) {
+		return mock.Obtain(context.Background(), domains, time.Time{})
+	}}
+	s.acme = fake
+
+	entry := newCertEntry([]string{"example.com"})
+	s.subscribe(entry)
+	defer s.release(entry)
+
+	time.Sleep(200 * time.Millisecond)
+	if got := fake.calls.Load(); got != 1 {
+		t.Fatalf("obtain called %d times, want 1 (renewer should sleep the long interval)", got)
+	}
+}
+
+// Stop must not return before the cache-file writer has stopped, otherwise the
+// documented shutdown drain races process exit.
+func TestStopJoinsTrackedGoroutines(t *testing.T) {
+	s := newTestServer(t)
+
+	stopped := make(chan struct{})
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		<-s.rootCtx.Done()
+		time.Sleep(50 * time.Millisecond) // stand-in for the drain + write
+		close(stopped)
+	}()
+
+	s.Stop()
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("Stop returned before the tracked goroutine finished")
+	}
+
+	// Stop is idempotent and Wait must not block once everything is done.
+	s.Stop()
+	s.Wait()
+}
+
+// Renewers must not be joined by Stop: lego's Obtain is not context-aware, so
+// a renewer parked in an issuance can only be waited out, and waiting burns
+// shutdownDrainTimeout (30s) — long enough to lose the race against the
+// caller's own shutdown deadline and turn a clean exit into a Fatal.
+func TestStopDoesNotWaitForParkedRenewer(t *testing.T) {
+	s := newTestServer(t)
+
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	s.acme = &fakeObtainer{fn: func(context.Context, []string) ([]byte, []byte, error) {
+		// Stands in for a lego Obtain that ignores ctx entirely.
+		once.Do(func() { close(parked) })
+		<-release
+		return nil, nil, fmt.Errorf("acme gave up")
+	}}
+	defer close(release)
+
+	entry := newCertEntry([]string{"example.com"})
+	s.subscribe(entry)
+
+	<-parked
+
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop blocked on a renewer parked inside ACME")
+	}
+}

--- a/pkg/tools/cert.go
+++ b/pkg/tools/cert.go
@@ -24,6 +24,19 @@ import (
 const (
 	permBundle  os.FileMode = 0o600
 	permCounter os.FileMode = 0o644
+
+	// DefaultLeafLifetime bounds how long an issued mTLS entity
+	// certificate stays valid. certdx has no revocation channel, so a
+	// leaked bundle is only contained by expiry.
+	DefaultLeafLifetime = 2 * 365 * 24 * time.Hour
+	// DefaultCALifetime bounds the self-signed CA. Long enough to
+	// outlive several leaf generations, short enough to force a
+	// rotation within a decade.
+	DefaultCALifetime = 10 * 365 * 24 * time.Hour
+
+	// firstEntitySerial is the serial handed to the first entity cert.
+	// RFC 5280 requires serials to be positive, so counting starts at 1.
+	firstEntitySerial = 1
 )
 
 // counter holds the serial number for the next certificate to be issued.
@@ -31,10 +44,57 @@ const (
 // successful signing.
 var counter big.Int
 
+// certOptions carries the tunable issuance parameters.
+type certOptions struct {
+	lifetime time.Duration
+}
+
+// CertOption customizes certificate issuance. Passing none keeps the
+// documented defaults, so existing callers stay source compatible.
+type CertOption func(*certOptions)
+
+// WithLifetime overrides the validity period of the issued certificate.
+//
+// Non-positive durations are ignored and the default is kept. That is a
+// library backstop only, so a caller that plumbs through an unvalidated
+// value still gets a usable certificate rather than one that expires
+// before it is written. Callers taking the duration from a user (the
+// --valid-for flag of make-{ca,server,client}) must reject a non-positive
+// value themselves instead of relying on this silent fallback.
+func WithLifetime(d time.Duration) CertOption {
+	return func(o *certOptions) {
+		if d > 0 {
+			o.lifetime = d
+		}
+	}
+}
+
+func buildOptions(defaultLifetime time.Duration, opts []CertOption) certOptions {
+	o := certOptions{lifetime: defaultLifetime}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	return o
+}
+
+// newCASerial draws a random positive 128-bit serial for a self-signed
+// CA, so it can never collide with the counter-issued entity serials.
+func newCASerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 127)
+	n, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, err
+	}
+	// RFC 5280 requires a positive serial number.
+	return n.Add(n, big.NewInt(1)), nil
+}
+
 // MakeCA creates a self-signed CA bundle (cert + key in a single PEM file)
 // at the default mTLS path. Fails if the file already exists to avoid
 // clobbering an in-use CA.
-func MakeCA(organization, commonName string) error {
+func MakeCA(organization, commonName string, opts ...CertOption) error {
+	o := buildOptions(DefaultCALifetime, opts)
+
 	caPath, err := paths.MtlsCAPath()
 	if err != nil {
 		return err
@@ -53,18 +113,27 @@ func MakeCA(organization, commonName string) error {
 		return fmt.Errorf("generating CA key: %w", err)
 	}
 
+	serial, err := newCASerial()
+	if err != nil {
+		return fmt.Errorf("generating CA serial: %w", err)
+	}
+
+	notBefore := time.Now().Truncate(1 * time.Hour)
 	ca := &x509.Certificate{
-		SerialNumber: big.NewInt(0),
+		SerialNumber: serial,
 		Subject: pkix.Name{
 			Organization: []string{organization},
 			CommonName:   commonName,
 		},
-		NotBefore:             time.Now().Truncate(1 * time.Hour),
-		NotAfter:              time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(o.lifetime),
 		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
-		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		// This CA only ever signs entity certs; forbid intermediates.
+		MaxPathLen:         0,
+		MaxPathLenZero:     true,
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
 	}
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &priv.PublicKey, priv)
@@ -77,15 +146,18 @@ func MakeCA(organization, commonName string) error {
 		return fmt.Errorf("marshaling CA key: %w", err)
 	}
 
+	// The counter is written first: a crash between the two writes must
+	// never leave a CA whose next serial is unknown (and reusable).
+	counter.SetInt64(firstEntitySerial)
+	if err := os.WriteFile(caCounterPath, []byte(counter.String()), permCounter); err != nil {
+		return fmt.Errorf("writing serial counter: %w", err)
+	}
+
 	if err := writeBundle(caPath,
 		pemBlock{"CERTIFICATE", caBytes},
 		pemBlock{"PRIVATE KEY", keyDER},
 	); err != nil {
 		return err
-	}
-
-	if err := os.WriteFile(caCounterPath, []byte(counter.String()), permCounter); err != nil {
-		return fmt.Errorf("writing serial counter: %w", err)
 	}
 
 	fmt.Printf("Wrote CA bundle: %s\n", caPath)
@@ -165,7 +237,9 @@ func splitIPsAndDNS(names []string) (dns []string, ips []net.IP) {
 }
 
 func makeCert(bundlePath, organization, commonName string,
-	domains []string, extKeyUsage []x509.ExtKeyUsage) error {
+	domains []string, extKeyUsage []x509.ExtKeyUsage, opts ...CertOption) error {
+
+	o := buildOptions(DefaultLeafLifetime, opts)
 
 	counterPath, err := paths.CACounterPath()
 	if err != nil {
@@ -193,16 +267,26 @@ func makeCert(bundlePath, organization, commonName string,
 		return fmt.Errorf("computing SKI: %w", err)
 	}
 
+	// Take a copy: the package-level counter is advanced below and must
+	// not alias the serial embedded in the certificate.
+	serial := new(big.Int).Set(&counter)
+	if serial.Sign() <= 0 {
+		// Counters written by pre-fix versions started at 0, which RFC
+		// 5280 forbids and which duplicates the old CA serial.
+		serial.SetInt64(firstEntitySerial)
+	}
+
+	notBefore := time.Now().Truncate(1 * time.Hour)
 	cert := &x509.Certificate{
-		SerialNumber: &counter,
+		SerialNumber: serial,
 		Subject: pkix.Name{
 			Organization: []string{organization},
 			CommonName:   commonName,
 		},
 		DNSNames:     dnsNames,
 		IPAddresses:  ipAddresses,
-		NotBefore:    time.Now().Truncate(1 * time.Hour),
-		NotAfter:     time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotBefore:    notBefore,
+		NotAfter:     notBefore.Add(o.lifetime),
 		ExtKeyUsage:  extKeyUsage,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		SubjectKeyId: skid,
@@ -218,6 +302,14 @@ func makeCert(bundlePath, organization, commonName string,
 		return fmt.Errorf("marshaling private key: %w", err)
 	}
 
+	// Persist the advanced counter before the bundle: a crash in
+	// between must burn a serial, never reuse one.
+	next := new(big.Int).Add(serial, big.NewInt(1))
+	if err := os.WriteFile(counterPath, []byte(next.String()), permCounter); err != nil {
+		return fmt.Errorf("writing serial counter: %w", err)
+	}
+	counter.Set(next)
+
 	// Entity bundle: entity cert + entity key + CA cert.
 	if err := writeBundle(bundlePath,
 		pemBlock{"CERTIFICATE", certBytes},
@@ -225,11 +317,6 @@ func makeCert(bundlePath, organization, commonName string,
 		pemBlock{"CERTIFICATE", caCert.Raw},
 	); err != nil {
 		return err
-	}
-
-	counter.Add(&counter, big.NewInt(1))
-	if err := os.WriteFile(counterPath, []byte(counter.String()), permCounter); err != nil {
-		return fmt.Errorf("writing serial counter: %w", err)
 	}
 
 	fmt.Printf("Wrote bundle: %s\n", bundlePath)
@@ -283,7 +370,9 @@ func writeBundle(path string, blocks ...pemBlock) error {
 }
 
 // MakeServerCert issues a named server certificate signed by the local CA.
-func MakeServerCert(name, organization, commonName string, domains []string) error {
+// The certificate is valid for DefaultLeafLifetime unless WithLifetime
+// says otherwise.
+func MakeServerCert(name, organization, commonName string, domains []string, opts ...CertOption) error {
 	if strings.EqualFold(strings.TrimSpace(name), "ca") {
 		return fmt.Errorf("name %q is reserved for CA material", name)
 	}
@@ -293,11 +382,13 @@ func MakeServerCert(name, organization, commonName string, domains []string) err
 		return err
 	}
 	return makeCert(bundlePath, organization, commonName, domains,
-		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, opts...)
 }
 
 // MakeClientCert issues a named client certificate signed by the local CA.
-func MakeClientCert(name, organization, commonName string, domains []string) error {
+// The certificate is valid for DefaultLeafLifetime unless WithLifetime
+// says otherwise.
+func MakeClientCert(name, organization, commonName string, domains []string, opts ...CertOption) error {
 	if strings.EqualFold(strings.TrimSpace(name), "ca") {
 		return fmt.Errorf("name %q is reserved for CA material", name)
 	}
@@ -307,5 +398,5 @@ func MakeClientCert(name, organization, commonName string, domains []string) err
 		return err
 	}
 	return makeCert(bundlePath, organization, commonName, domains,
-		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, opts...)
 }

--- a/pkg/tools/cert_test.go
+++ b/pkg/tools/cert_test.go
@@ -4,12 +4,68 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/pem"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"pkg.para.party/certdx/pkg/paths"
 )
+
+// withDataDir points paths at a fresh temp data root for the duration of
+// the test and resets the package-level serial counter.
+func withDataDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "data")
+	paths.SetDataDir(dir)
+	counter.SetInt64(0)
+	t.Cleanup(func() {
+		paths.SetDataDir("")
+		counter.SetInt64(0)
+	})
+	return dir
+}
+
+// firstCertInBundle parses the leading CERTIFICATE block of a bundle.
+func firstCertInBundle(t *testing.T, path string) *x509.Certificate {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	certPEM, _ := splitCertAndKeyPEM(data)
+	if certPEM == nil {
+		t.Fatalf("no CERTIFICATE block in %s", path)
+	}
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert in %s: %v", path, err)
+	}
+	return cert
+}
+
+func readCounter(t *testing.T) *big.Int {
+	t.Helper()
+	p, err := paths.CACounterPath()
+	if err != nil {
+		t.Fatalf("CACounterPath: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	n, ok := new(big.Int).SetString(strings.TrimSpace(string(data)), 10)
+	if !ok {
+		t.Fatalf("counter file is not a number: %q", data)
+	}
+	return n
+}
 
 func TestSplitIPsAndDNS(t *testing.T) {
 	dns, ips := splitIPsAndDNS([]string{
@@ -169,5 +225,203 @@ func TestMakeClientCertServerNameAllowed(t *testing.T) {
 	}
 	if err.Error() == `name "server" is reserved for CA material` {
 		t.Fatal("'server' should no longer be reserved")
+	}
+}
+
+func TestMakeCASerialAndConstraints(t *testing.T) {
+	withDataDir(t)
+
+	if err := MakeCA("org", "cn"); err != nil {
+		t.Fatalf("MakeCA: %v", err)
+	}
+
+	caPath, err := paths.MtlsCAPath()
+	if err != nil {
+		t.Fatalf("MtlsCAPath: %v", err)
+	}
+	ca := firstCertInBundle(t, caPath)
+
+	if ca.SerialNumber.Sign() <= 0 {
+		t.Errorf("CA serial = %s, want positive (RFC 5280)", ca.SerialNumber)
+	}
+	if !ca.IsCA || !ca.BasicConstraintsValid {
+		t.Error("CA is missing basic constraints")
+	}
+	if !ca.MaxPathLenZero || ca.MaxPathLen != 0 {
+		t.Errorf("CA pathLen = %d (zero=%t), want 0/true", ca.MaxPathLen, ca.MaxPathLenZero)
+	}
+	if got := ca.NotAfter.Sub(ca.NotBefore); got != DefaultCALifetime {
+		t.Errorf("CA lifetime = %s, want %s", got, DefaultCALifetime)
+	}
+	if ca.NotAfter.Year() >= 2100 {
+		t.Errorf("CA NotAfter = %s, still effectively unbounded", ca.NotAfter)
+	}
+
+	// The counter must be initialized to the first positive serial.
+	if got, want := readCounter(t), big.NewInt(firstEntitySerial); got.Cmp(want) != 0 {
+		t.Errorf("counter after MakeCA = %s, want %s", got, want)
+	}
+}
+
+func TestEntitySerialsArePositiveAndUnique(t *testing.T) {
+	withDataDir(t)
+
+	if err := MakeCA("org", "cn"); err != nil {
+		t.Fatalf("MakeCA: %v", err)
+	}
+	caPath, _ := paths.MtlsCAPath()
+	ca := firstCertInBundle(t, caPath)
+
+	if err := MakeServerCert("server", "org", "cn", []string{"localhost"}); err != nil {
+		t.Fatalf("MakeServerCert: %v", err)
+	}
+	if err := MakeClientCert("client", "org", "cn", nil); err != nil {
+		t.Fatalf("MakeClientCert: %v", err)
+	}
+
+	srvPath, _ := paths.MtlsBundlePath("server")
+	cliPath, _ := paths.MtlsBundlePath("client")
+	srv := firstCertInBundle(t, srvPath)
+	cli := firstCertInBundle(t, cliPath)
+
+	for name, c := range map[string]*x509.Certificate{"server": srv, "client": cli} {
+		if c.SerialNumber.Sign() <= 0 {
+			t.Errorf("%s serial = %s, want positive", name, c.SerialNumber)
+		}
+		if c.SerialNumber.Cmp(ca.SerialNumber) == 0 {
+			t.Errorf("%s serial duplicates the CA serial %s", name, c.SerialNumber)
+		}
+	}
+	if srv.SerialNumber.Cmp(cli.SerialNumber) == 0 {
+		t.Errorf("server and client share serial %s", srv.SerialNumber)
+	}
+	if got, want := srv.SerialNumber, big.NewInt(1); got.Cmp(want) != 0 {
+		t.Errorf("first entity serial = %s, want %s", got, want)
+	}
+	if got, want := readCounter(t), big.NewInt(3); got.Cmp(want) != 0 {
+		t.Errorf("counter after two certs = %s, want %s", got, want)
+	}
+}
+
+func TestEntityCertLifetimeIsBounded(t *testing.T) {
+	withDataDir(t)
+
+	if err := MakeCA("org", "cn"); err != nil {
+		t.Fatalf("MakeCA: %v", err)
+	}
+	if err := MakeServerCert("server", "org", "cn", []string{"localhost"}); err != nil {
+		t.Fatalf("MakeServerCert: %v", err)
+	}
+
+	srvPath, _ := paths.MtlsBundlePath("server")
+	srv := firstCertInBundle(t, srvPath)
+
+	if got := srv.NotAfter.Sub(srv.NotBefore); got != DefaultLeafLifetime {
+		t.Errorf("leaf lifetime = %s, want %s", got, DefaultLeafLifetime)
+	}
+	if srv.NotAfter.Year() >= 2100 {
+		t.Errorf("leaf NotAfter = %s, still effectively unbounded", srv.NotAfter)
+	}
+}
+
+func TestWithLifetimeOverride(t *testing.T) {
+	withDataDir(t)
+
+	if err := MakeCA("org", "cn", WithLifetime(48*time.Hour)); err != nil {
+		t.Fatalf("MakeCA: %v", err)
+	}
+	if err := MakeClientCert("client", "org", "cn", nil, WithLifetime(24*time.Hour)); err != nil {
+		t.Fatalf("MakeClientCert: %v", err)
+	}
+
+	caPath, _ := paths.MtlsCAPath()
+	cliPath, _ := paths.MtlsBundlePath("client")
+	ca := firstCertInBundle(t, caPath)
+	cli := firstCertInBundle(t, cliPath)
+
+	if got := ca.NotAfter.Sub(ca.NotBefore); got != 48*time.Hour {
+		t.Errorf("CA lifetime = %s, want 48h", got)
+	}
+	if got := cli.NotAfter.Sub(cli.NotBefore); got != 24*time.Hour {
+		t.Errorf("leaf lifetime = %s, want 24h", got)
+	}
+
+	// Non-positive durations fall back to the default.
+	if err := MakeServerCert("server", "org", "cn", []string{"localhost"}, WithLifetime(0)); err != nil {
+		t.Fatalf("MakeServerCert: %v", err)
+	}
+	srvPath, _ := paths.MtlsBundlePath("server")
+	srv := firstCertInBundle(t, srvPath)
+	if got := srv.NotAfter.Sub(srv.NotBefore); got != DefaultLeafLifetime {
+		t.Errorf("lifetime with WithLifetime(0) = %s, want default %s", got, DefaultLeafLifetime)
+	}
+}
+
+// WithLifetime keeps the default for a non-positive duration. This is only a
+// library backstop: the --valid-for flag of make-{ca,server,client} rejects
+// such a value before it ever reaches here (see exec/tools/tasks/make-*.go).
+func TestWithLifetimeIgnoresNonPositiveDurations(t *testing.T) {
+	for _, d := range []time.Duration{0, -1, -24 * time.Hour} {
+		if got := buildOptions(DefaultLeafLifetime, []CertOption{WithLifetime(d)}); got.lifetime != DefaultLeafLifetime {
+			t.Errorf("WithLifetime(%s) => lifetime %s, want default %s", d, got.lifetime, DefaultLeafLifetime)
+		}
+	}
+	if got := buildOptions(DefaultCALifetime, []CertOption{WithLifetime(time.Hour)}); got.lifetime != time.Hour {
+		t.Errorf("WithLifetime(1h) => lifetime %s, want 1h", got.lifetime)
+	}
+}
+
+func TestLegacyZeroCounterIsBumpedToPositive(t *testing.T) {
+	withDataDir(t)
+
+	if err := MakeCA("org", "cn"); err != nil {
+		t.Fatalf("MakeCA: %v", err)
+	}
+	// Simulate a CA created by a pre-fix version, whose counter file
+	// holds the non-positive serial 0.
+	counterPath, _ := paths.CACounterPath()
+	if err := os.WriteFile(counterPath, []byte("0"), permCounter); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+
+	if err := MakeServerCert("server", "org", "cn", []string{"localhost"}); err != nil {
+		t.Fatalf("MakeServerCert: %v", err)
+	}
+	srvPath, _ := paths.MtlsBundlePath("server")
+	srv := firstCertInBundle(t, srvPath)
+	if srv.SerialNumber.Sign() <= 0 {
+		t.Fatalf("leaf serial = %s, want positive", srv.SerialNumber)
+	}
+}
+
+func TestCounterPersistedBeforeBundle(t *testing.T) {
+	withDataDir(t)
+
+	if err := MakeCA("org", "cn"); err != nil {
+		t.Fatalf("MakeCA: %v", err)
+	}
+	if err := MakeServerCert("server", "org", "cn", []string{"localhost"}); err != nil {
+		t.Fatalf("MakeServerCert: %v", err)
+	}
+
+	srvPath, _ := paths.MtlsBundlePath("server")
+	counterPath, _ := paths.CACounterPath()
+
+	bundleInfo, err := os.Stat(srvPath)
+	if err != nil {
+		t.Fatalf("stat bundle: %v", err)
+	}
+	counterInfo, err := os.Stat(counterPath)
+	if err != nil {
+		t.Fatalf("stat counter: %v", err)
+	}
+	if counterInfo.ModTime().After(bundleInfo.ModTime()) {
+		t.Error("serial counter was written after the bundle; a crash in between would reuse a serial")
+	}
+
+	// The persisted counter must already be past the issued serial.
+	srv := firstCertInBundle(t, srvPath)
+	if readCounter(t).Cmp(srv.SerialNumber) <= 0 {
+		t.Error("persisted counter is not greater than the issued serial")
 	}
 }


### PR DESCRIPTION
## Overview

Applies the verified fixes from a full-project code review (48 findings: 13 high / 22 medium / 13 low), followed by an adversarial regression pass that caught and fixed several bad fixes before this PR.

**Backward compatible** — no TOML-schema or CLI-flag breaks; only internal Go APIs changed. Every config that loaded before still loads (tightened validation always has an escape hatch or a safe default).

**Verified**: all 6 modules `build` / `vet` / `gofmt` clean and pass `go test -race`; the full e2e suite passes (32/32), including the HTTP renewal + failover tests that exercise the touched serving path.

## Highlights by area

### Server — cert cache & serving
- **SDS crash & wedge (high):** a version-mismatched frame with no `ErrorDetail` used to nil-panic and kill the whole daemon — now guarded, plus a per-stream `recover`. `reqChan` is buffered / selected so a standard single-stream multi-pack Envoy SotW ACK no longer wedges the receive loop.
- **HTTP empty-cert (high):** the API could return `200` with empty fullchain/key while a pack was still being issued, causing clients to overwrite good certs with empty files — now `503` until real material exists. Malformed/empty requests return `400`; token compare is constant-time.
- **Validity math:** `renew()` now clamps `ValidBefore` against the leaf's real `NotAfter` (floored so a fresh cert is never born invalid), and retries on a short backoff when an entry holds no valid cert instead of sleeping `RenewTimeLeft/4`.
- **Lifecycle:** persistence gated on the server's root ctx (not the caller's), `Stop()` drains the cache writer without hanging on renewers, atomic `cache.json` write, per-request domain-set verification + optional entry cap.

### Client
- **`os.Exit` from library code (high):** `pkg/client` constructors return errors instead of `logging.Fatal` — this also stops the Caddy plugin from taking down the whole process on a bad mTLS bundle.
- Reload command runs with a bounded timeout; atomic writes `fsync` (best-effort on mounts that refuse it); poll interval floored only in the pathological case (short renewal cadences preserved); a well-formed server error-response no longer triggers a tight retry loop; reused HTTP transport; duplicate SDS dispatch-key guard.

### ACME / config
- DNS-01 propagation is now actually verified on the configured recursive nameservers; account-key overwrite requires `--force` and is restored on failure; S3 challenge ACL is configurable (**unset preserves the historical `public-read`**, `acl = ""` opts out for modern buckets).
- Validation added for durations, `authMethod`, empty/insecure token, nameservers, S3 fields, and duplicate client certifications — each with an escape hatch or safe default.

### Tools
- **Tencent updater:** confirms re-binds via deploy records before reporting success, compares real `CertEndTime`, distinguishes terminal vs transient API errors (no retry storms), and enforces a hard run deadline for cron alerting.
- **Kubernetes updater:** additive wildcard-coverage matcher (a secret annotated `foo.example.com` is now covered by a `*.example.com` pack), server-side `type=kubernetes.io/tls` field selector + pagination (no more pulling every secret into memory), richer timeout errors.
- **mTLS material:** bounded lifetimes + `MaxPathLen` instead of year-2100 certs; positive serial numbers.

### Foundation
- Atomic logger (fixes the config-reload data race), `pkg/mtls` tests + empty-pool load error, path-component sanitization. Focused unit tests added throughout.

## Known follow-ups (not blockers)
- Tencent updater: no `--timeout` flag yet (10-min run / 5-min deploy-confirm are constants); `DescribeHostUpdateRecordDetail` is unpaginated.
- e2e caddytls tests hard-fail (instead of `t.Skip`) when `xcaddy` is absent — pre-existing, in the untouched `test/e2e` harness.

## Review method
Findings were produced by scoped reviewers and each independently verified by an adversarial pass (must trace the failure in real code to confirm, or cite the code that prevents it to refute). Fixes were then re-reviewed for regressions, and the regressions found were fixed and re-verified against the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
